### PR TITLE
Fix edit field render bug(CommentForm)

### DIFF
--- a/webapp/components/comments/CommentForm/index.vue
+++ b/webapp/components/comments/CommentForm/index.vue
@@ -5,14 +5,12 @@
   >
     <template slot-scope="{ errors }">
       <ds-card>
-        <no-ssr>
-          <hc-editor
-            ref="editor"
-            :users="users"
-            :value="form.content"
-            @input="updateEditorContent"
-          />
-        </no-ssr>
+        <hc-editor
+          ref="editor"
+          :users="users"
+          :value="form.content"
+          @input="updateEditorContent"
+        />
         <ds-space />
         <ds-flex :gutter="{ base: 'small', md: 'small', sm: 'x-large', xs: 'x-large' }">
           <ds-flex-item :width="{ base: '0%', md: '50%', sm: '0%', xs: '0%' }" />

--- a/webapp/components/comments/CommentForm/spec.js
+++ b/webapp/components/comments/CommentForm/spec.js
@@ -1,12 +1,10 @@
-import { config, mount, createLocalVue, createWrapper } from '@vue/test-utils'
+import { mount, createLocalVue, createWrapper } from '@vue/test-utils'
 import CommentForm from './index.vue'
 import Styleguide from '@human-connection/styleguide'
 
 const localVue = createLocalVue()
 
 localVue.use(Styleguide)
-
-config.stubs['no-ssr'] = '<span><slot /></span>'
 
 describe('CommentForm.vue', () => {
   let mocks

--- a/webapp/components/comments/CommentList/CommentList.spec.js
+++ b/webapp/components/comments/CommentList/CommentList.spec.js
@@ -33,6 +33,13 @@ describe('CommentList.vue', () => {
   })
   mocks = {
     $t: jest.fn(),
+    $apollo: {
+      queries: {
+        Post: {
+          refetch: jest.fn(),
+        },
+      },
+    },
   }
   data = () => {
     return {
@@ -62,6 +69,11 @@ describe('CommentList.vue', () => {
 
     it('displays comments when there are comments to display', () => {
       expect(wrapper.find('div#comments').text()).toEqual('this is a comment')
+    })
+
+    it("refetches a post's comments from the backend", () => {
+      wrapper.vm.refetchPostComments()
+      expect(mocks.$apollo.queries.Post.refetch).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/webapp/components/comments/CommentList/index.vue
+++ b/webapp/components/comments/CommentList/index.vue
@@ -54,13 +54,15 @@ export default {
     },
   },
   mounted() {
-    this.$root.$on('refetchPostComments', comment => {
-      this.refetchPostComments(comment)
+    this.$root.$on('refetchPostComments', () => {
+      this.refetchPostComments()
     })
   },
   methods: {
-    refetchPostComments(comment) {
-      this.$apollo.queries.Post.refetch()
+    refetchPostComments() {
+      if (this.$apollo.queries.Post) {
+        this.$apollo.queries.Post.refetch()
+      }
     },
   },
   apollo: {


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-05-27T20:06:42Z" title="Monday, May 27th 2019, 10:06:42 pm +02:00">May 27, 2019</time>_
_Merged <time datetime="2019-05-27T22:46:05Z" title="Tuesday, May 28th 2019, 12:46:05 am +02:00">May 28, 2019</time>_
---

- remove no-ssr, which was not necessary and causing the edit field not to appear the majority of the times visiting a Post.
- this was really bad user experience since a user would need to refresh the page to comment.
- removed args in refetchPostComments as there are no params passed in when it is called anymore
- needed to add an if statement since if there are no comments on a Post, then this.$apollo.queries.Post is undefined and it errors out trying to call refetch()
- update test to remove no-ssr

Co-authored-by: Mike Aono <aonomike@gmail.com>

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #582 
