### PR TITLE
Fix placeholder text not translating bug

### DIFF
--- a/webapp/components/Editor/index.vue
+++ b/webapp/components/Editor/index.vue
@@ -327,10 +327,18 @@ export default {
       },
     },
   },
+  mounted() {
+    this.$root.$on('changeLanguage', () => {
+      this.changePlaceHolderText()
+    })
+  },
   beforeDestroy() {
     this.editor.destroy()
   },
   methods: {
+    changePlaceHolderText() {
+      this.editor.extensions.options.placeholder.emptyNodeText = this.$t('editor.placeholder')
+    },
     // navigate to the previous item
     // if it's the first item, navigate to the last one
     upHandler() {

--- a/webapp/components/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch.vue
@@ -14,7 +14,8 @@
       <ds-icon
         style="margin-right: 2px;"
         name="globe"
-      /> {{ current.code.toUpperCase() }}
+      />
+      {{ current.code.toUpperCase() }}
       <ds-icon
         style="margin-left: 2px"
         size="xx-small"
@@ -78,6 +79,7 @@ export default {
     changeLanguage(locale, toggleMenu) {
       this.$i18n.set(locale)
       toggleMenu()
+      this.$root.$emit('changeLanguage')
     },
     matcher(locale) {
       return locale === this.$i18n.locale()


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-05-28T15:53:18Z" title="Tuesday, May 28th 2019, 5:53:18 pm +02:00">May 28, 2019</time>_
_Merged <time datetime="2019-05-29T06:08:30Z" title="Wednesday, May 29th 2019, 8:08:30 am +02:00">May 29, 2019</time>_
---

- tiptap-extensions are not reactive
- we must call a method to change them dynamically
- emit changeLanguage event, which is listened for by the Editor component, which then calls a method to set the emptyNodeText of tiptap

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #583 
