### PR TITLE
Run coverage only if requested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 script:
   # Backend
   - docker-compose exec backend yarn run lint
-  - docker-compose exec backend yarn run test:jest --ci --verbose=false
+  - docker-compose exec backend yarn run test:jest --ci --verbose=false --coverage
   - docker-compose exec backend yarn run db:reset
   - docker-compose exec backend yarn run db:seed
   - docker-compose exec backend yarn run test:cucumber
@@ -30,7 +30,7 @@ script:
   - docker-compose exec backend yarn run db:seed
   # Frontend
   - docker-compose exec webapp yarn run lint
-  - docker-compose exec webapp yarn run test --ci --verbose=false
+  - docker-compose exec webapp yarn run test --ci --verbose=false --coverage
   - docker-compose exec -d backend yarn run test:before:seeder
   # Fullstack
   - CYPRESS_RETRIES=1 yarn run cypress:run

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,6 @@
   "license": "MIT",
   "jest": {
     "verbose": true,
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.js",
       "!**/node_modules/**",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,6 @@
   },
   "jest": {
     "verbose": true,
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{js,vue}",
       "!**/node_modules/**",


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-05-28T16:29:19Z" title="Tuesday, May 28th 2019, 6:29:19 pm +02:00">May 28, 2019</time>_
_Merged <time datetime="2019-05-28T19:11:50Z" title="Tuesday, May 28th 2019, 9:11:50 pm +02:00">May 28, 2019</time>_
---

I find it annoying to wait for code coverage tools to complete (~3
seconds) and especially to scroll up for every test run. So, this should
run coverage only on our build server *or* if you add `--coverage` on
the command line.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
