### PR TITLE
DISABLED_MIDDLEWARES only set outside production

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src --config .eslintrc.js",
     "test": "run-s test:jest test:cucumber",
     "test:before:server": "cross-env GRAPHQL_URI=http://localhost:4123 GRAPHQL_PORT=4123 yarn run dev 2> /dev/null",
-    "test:before:seeder": "cross-env GRAPHQL_URI=http://localhost:4001 GRAPHQL_PORT=4001 DEBUG=true DISABLED_MIDDLEWARES=permissions,activityPub yarn run dev 2> /dev/null",
+    "test:before:seeder": "cross-env GRAPHQL_URI=http://localhost:4001 GRAPHQL_PORT=4001 DISABLED_MIDDLEWARES=permissions,activityPub yarn run dev 2> /dev/null",
     "test:jest:cmd": "wait-on tcp:4001 tcp:4123 && jest --forceExit --detectOpenHandles --runInBand",
     "test:cucumber:cmd": "wait-on tcp:4001 tcp:4123 && cucumber-js --require-module @babel/register --exit test/",
     "test:jest:cmd:debug": "wait-on tcp:4001 tcp:4123 && node --inspect-brk ./node_modules/.bin/jest -i --forceExit --detectOpenHandles --runInBand",
@@ -19,8 +19,8 @@
     "test:cucumber": " cross-env CLIENT_URI=http://localhost:4123 run-p --race test:before:* 'test:cucumber:cmd {@}' --",
     "test:jest:debug": "run-p --race test:before:* 'test:jest:cmd:debug {@}' --",
     "db:script:seed": "wait-on tcp:4001 && babel-node src/seed/seed-db.js",
-    "db:reset": "cross-env DEBUG=true babel-node src/seed/reset-db.js",
-    "db:seed": "cross-env GRAPHQL_URI=http://localhost:4001 GRAPHQL_PORT=4001 DEBUG=true DISABLED_MIDDLEWARES=permissions run-p --race dev db:script:seed"
+    "db:reset": "cross-env babel-node src/seed/reset-db.js",
+    "db:seed": "cross-env GRAPHQL_URI=http://localhost:4001 GRAPHQL_PORT=4001 DISABLED_MIDDLEWARES=permissions run-p --race dev db:script:seed"
   },
   "author": "Human Connection gGmbH",
   "license": "MIT",

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -23,7 +23,8 @@ export const serverConfigs = {
 export const developmentConfigs = {
   DEBUG: process.env.NODE_ENV !== 'production' && process.env.DEBUG === 'true',
   MOCKS: process.env.MOCKS === 'true',
-  DISABLED_MIDDLEWARES: process.env.DISABLED_MIDDLEWARES || '',
+  DISABLED_MIDDLEWARES:
+    (process.env.NODE_ENV !== 'production' && process.env.DISABLED_MIDDLEWARES) || '',
 }
 
 export default {

--- a/backend/src/middleware/index.js
+++ b/backend/src/middleware/index.js
@@ -50,7 +50,7 @@ export default schema => {
   ]
 
   // add permisions middleware at the first position (unless we're seeding)
-  if (CONFIG.DEBUG) {
+  if (CONFIG.DISABLED_MIDDLEWARES) {
     const disabledMiddlewares = CONFIG.DISABLED_MIDDLEWARES.split(',')
     order = order.filter(key => {
       return !disabledMiddlewares.includes(key)

--- a/backend/src/seed/reset-db.js
+++ b/backend/src/seed/reset-db.js
@@ -1,8 +1,7 @@
 import { cleanDatabase } from './factories'
-import CONFIG from './../config'
 
-if (!CONFIG.DEBUG) {
-  throw new Error(`YOU CAN'T CLEAN THE DATABASE WITH DEBUG=${CONFIG.DEBUG}`)
+if (process.env.NODE_ENV === 'production') {
+  throw new Error(`You cannot clean the database in production environment!`)
 }
 
 ;(async function() {


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-04T10:52:58Z" title="Tuesday, June 4th 2019, 12:52:58 pm +02:00">Jun 4, 2019</time>_
_Merged <time datetime="2019-06-04T22:45:33Z" title="Wednesday, June 5th 2019, 12:45:33 am +02:00">Jun 5, 2019</time>_
---

That way, we don't see verbose logging output on Travis. Setting DEBUG
will have the effect that all calls of `neo4jgraphql` will produce log
output.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
