### PR TITLE
Fix #799

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,4 +24,5 @@ RUN yarn run build
 FROM base as production
 ENV NODE_ENV=production
 COPY --from=builder /nitro-backend/dist ./dist
+COPY ./public/img/ ./public/img/
 RUN yarn install --frozen-lockfile --non-interactive


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-12T21:57:06Z" title="Wednesday, June 12th 2019, 11:57:06 pm +02:00">Jun 12, 2019</time>_
_Merged <time datetime="2019-06-12T22:16:21Z" title="Thursday, June 13th 2019, 12:16:21 am +02:00">Jun 13, 2019</time>_
---

For target `production` the badges were simply not copied. It also
explains why we never saw that error in development. For development we
use docker build target `build-and-test`.

FYI: @ulfgebhardt @Tirokk @ogerly

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fix #799 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
