### PR TITLE
large images are set to maximum height

### DIFF
--- a/webapp/components/PostCard/index.vue
+++ b/webapp/components/PostCard/index.vue
@@ -8,7 +8,9 @@
       <nuxt-link
         class="post-link"
         :to="{ name: 'post-id-slug', params: { id: post.id, slug: post.slug } }"
-      >{{ post.title }}</nuxt-link>
+      >
+        {{ post.title }}
+      </nuxt-link>
       <ds-space margin-bottom="small" />
       <!-- Username, Image & Date of Post -->
       <div>

--- a/webapp/components/PostCard/index.vue
+++ b/webapp/components/PostCard/index.vue
@@ -8,9 +8,7 @@
       <nuxt-link
         class="post-link"
         :to="{ name: 'post-id-slug', params: { id: post.id, slug: post.slug } }"
-      >
-        {{ post.title }}
-      </nuxt-link>
+      >{{ post.title }}</nuxt-link>
       <ds-space margin-bottom="small" />
       <!-- Username, Image & Date of Post -->
       <div>
@@ -128,6 +126,15 @@ export default {
 </script>
 
 <style lang="scss">
+.ds-card-image img {
+  width: 100%;
+  max-height: 300px;
+  -o-object-fit: cover;
+  object-fit: cover;
+  -o-object-position: center;
+  object-position: center;
+}
+
 .post-card {
   cursor: pointer;
   position: relative;


### PR DESCRIPTION
> [<img alt="ogerly" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/ogerly) **Authored by [ogerly](https://github.com/ogerly)**
_<time datetime="2019-07-04T09:02:11Z" title="Thursday, July 4th 2019, 11:02:11 am +02:00">Jul 4, 2019</time>_
_Merged <time datetime="2019-07-09T21:21:28Z" title="Tuesday, July 9th 2019, 11:21:28 pm +02:00">Jul 9, 2019</time>_
---

## 🍰 Pullrequest
large images are also set to a maximum height of 300px on the overview page and centered vertically and horizontally

 
 
 
![FireShot Capture 157 - Human Connection - Human Connection - localhost](https://user-images.githubusercontent.com/1324583/60653939-49d5e080-9e4b-11e9-951a-58c4dc017571.png)



# Example image

![FireShot Capture 156 - Absolute Center (Vertical   Horizontal) an Image - CSS-Tricks_ - css-tricks com](https://user-images.githubusercontent.com/1324583/60653744-ef3c8480-9e4a-11e9-899a-ef3bc8d3e755.png)


### Issues
- fixes #https://github.com/Human-Connection/Human-Connection/issues/961

