### PR TITLE
Update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Thanks so much for thinking of contributing to the Human Connection project, we 
 
 ## Getting Set Up
 
-Instructions for how to install all the necessary software can be found in our [documentation](https://docs.human-connection.org/human-connection/)
+Instructions for how to install all the necessary software can be found in our [documentation](https://docs.human-connection.org/human-connection/).
 
-We recommend that new folks should ideally work together with an existing developer. Please join our discord instance to chat with developers or just ask them in tickets in [Zenhub](https://app.zenhub.com/workspaces/human-connection-nitro-5c0154ecc699f60fc92cf11f/boards?repos=152252353):
+We recommend that new folks should ideally work together with an existing developer. Please join our [discord](https://discord.gg/6ub73U3) instance to chat with developers or just ask them in tickets in [Zenhub](https://app.zenhub.com/workspaces/human-connection-nitro-5c0154ecc699f60fc92cf11f/boards?repos=152252353):
 
 ![](https://dl.dropbox.com/s/vbmcihkduy9dhko/Screenshot%202019-01-03%2015.50.11.png?dl=0)
 
@@ -17,7 +17,7 @@ Here are some general notes on our development flow:
 * Currently operating in two week sprints
 * We are using ZenHub to coordinate
   * estimating time per issue is the crucial feature of [Zenhub](https://app.zenhub.com/workspaces/human-connection-nitro-5c0154ecc699f60fc92cf11f) that Github does not have
-  * "up-for-grabs" links to [Github project](https://github.com/orgs/Human-Connection/projects/10?card_filter_query=label%3A"good+first+issue)
+  * "up-for-grabs" links to [Github project](https://github.com/Human-Connection/Human-Connection/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
   * ordering on ZenHub not necessarily reflected on github projects
 * AgileVentures run open pairing sessions at 10:30am UTC each week on Tuesdays and Thursdays
 * Core team
@@ -51,19 +51,19 @@ But what do we do when waiting for merge into master \(wanting to keep PRs small
   * solutions
     * 1\) put 2nd PR into branch that the first PR is hitting - but requires update after merging
     * 2\) prefer to leave exiting PR until it can be reviewed, and instead go and work on some other part of the codebase that is not impacted by the first PR
-    
+
 ### Code Review
-* Github setting in place - at least one review is required to merge 
+* Github setting in place - at least one review is required to merge
   - in principle anyone (who is not the PR owner) can review
   - but often it will be the core developers (Robert, Ulf, Greg, Wolfgang?)
   - once there is a review, and presuming no requested changes, PR opener can merge
 
 * CI/tests
-  - the CI needs to pass 
+  - the CI needs to pass
     - linting  <-- autofix?
     - tests (unit, feature) (backend, frontend)
     - codecoverage
-    
+
 ## Notes
 
 question: when you want to pick a task - \(find out priority\) - is it in discord? is it in AV slack? --&gt; Robert says you can always ask in discord - group channels are the best
@@ -77,4 +77,3 @@ Matt makes point that new stories will have to be taken off the "New Issues" and
 Robert notes that everyone is invited to join the kickoff meetings
 
 Robert - difference between "important" \(creates a lot of value\) and "beginner friendly" \(easy to implement\)
-

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Thank you lokalise for providing us with a premium account :raised_hands:.
 ## Developer Chat
 
 Join our friendly open-source community on [Discord](https://discord.gg/6ub73U3) :heart_eyes_cat:
-Just introduce yourself at `#user-presentation` and mention `@@Mentor` to get you onboard :neckbeard:
+Just introduce yourself at `#introduce-yourself` and mention `@@Mentor` to get you onboard :neckbeard:
 Check out the [contribution guideline](./CONTRIBUTING.md), too!
 
 

--- a/cypress/features.md
+++ b/cypress/features.md
@@ -16,7 +16,7 @@ The following features will be implemented. This gets done in three steps:
 
 ### User Account
 
-[Cucumber Features](./integration/user_account)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/user_account)
 
 * Sign-up
 * Agree to Data Privacy Statement
@@ -34,7 +34,7 @@ The following features will be implemented. This gets done in three steps:
 
 ### User Profile
 
-[Cucumber Features](./integration/user_profile)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/user_profile)
 
 * Upload and Change Avatar
 * Upload and Change Profile Picture
@@ -59,7 +59,7 @@ The following features will be implemented. This gets done in three steps:
 
 ### Posts
 
-[Cucumber Features](./integration/post/)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/post)
 
 * Creating Posts
 * Persistent Links
@@ -78,13 +78,13 @@ The following features will be implemented. This gets done in three steps:
 
 ### Comments
 
-* Creating Comments 
+* Creating Comments
 * Deleting Comments
 * Editing Comments
 * Upvote comments of others
 
 ### Notifications
-[Cucumber features](./integration/notifications)
+[Cucumber features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/notifications)
 
 * User @-mentionings
 * Notify authors for comments
@@ -94,12 +94,12 @@ The following features will be implemented. This gets done in three steps:
 
 * Show Posts by Tiles
 * Show Posts as List
-* Filter by Category \(Health and Wellbeing, Global Peace & Non-Violence, ...\) 
+* Filter by Category \(Health and Wellbeing, Global Peace & Non-Violence, ...\)
 * Filter by Mood \(Funny, Happy, Surprised, Cry, Angry, ...\)
 * Filter by Source \(Connections, Following, Individuals, Non-Profits, ...\)
 * Filter by Posts & Tools \(Post, Events, CanDos, ...\)
 * Filter by Format Type \(Text, Pictures, Video, ...\)
-* Extended Filter \(Continent, Country, Language, ...\) 
+* Extended Filter \(Continent, Country, Language, ...\)
 * Sort Posts by Date
 * Sort Posts by Shouts
 * Sort Posts by most Comments
@@ -116,7 +116,7 @@ The following features will be implemented. This gets done in three steps:
 
 ### Search
 
-[Cucumber Features](./integration/search)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/search)
 
 * Search for Categories
 * Search for Tags
@@ -186,13 +186,13 @@ The following features will be implemented. This gets done in three steps:
 
 ### More Info
 
-Shows autmatically releated information for existing post.
+Shows automatically related information for existing post.
 
 * Show related Posts
 * Show Pros and Cons
 * Show Bestlist
 * Show Votes
-* Link to corresponding Chatroom 
+* Link to corresponding Chatroom
 
 ### Take Action
 
@@ -237,7 +237,7 @@ Shows automatically related actions for existing post.
 
 ### Moderation
 
-[Cucumber Features](./integration/moderation)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/moderation)
 
 * Report Button for users for doubtful Content
 * Moderator Panel
@@ -262,7 +262,7 @@ Shows automatically related actions for existing post.
 
 ### Internationalization
 
-[Cucumber Features](./integration/internationalization)
+[Cucumber Features](https://github.com/Human-Connection/Human-Connection/tree/master/cypress/integration/internationalization)
 
 * Frontend UI
 * Backend Error Messages
@@ -276,4 +276,3 @@ Shows automatically related actions for existing post.
 * Receiving Undo and Delete Activities for Articles and Notes
 * Serving Webfinger records and Actor Objects
 * Serving Followers, Following and Outbox collections
-

--- a/edit-this-documentation.md
+++ b/edit-this-documentation.md
@@ -1,12 +1,6 @@
 # Edit this Documentation
 
-Go to the section and theme you want to change: On the left navigator.
-
-Click **Edit on GitHub** on the right.
-
-On the **Issue** tab you’ll find the open issues. Read what need to be done by clicking on the issue you like to fix.
-
-By going backwards in the browser **\(!\)**, again go to the **Code** tab.
+Find the [**table of contents** for this documentation on GitHub](https://github.com/Human-Connection/Human-Connection/blob/master/SUMMARY.md) and navigate to the file you need to update.
 
 Click on the **edit pencil** on the right side directly above the text to edit this file on your fork of Human Connection \(HC\).
 
@@ -14,7 +8,7 @@ You can see a preview of your changes by clicking the **Preview changes** tab as
 
 If you are ready, fill in the **Propose file change** at the end of the webpage.
 
-After that you have to send your change to the HC basis with a pull request. Here make a comment which issue you have fixed. At least the number.
+After that you have to send your change to the HC basis with a pull request. Here make a comment which issue you have fixed. (If you are working on one of our [open issues](https://github.com/Human-Connection/Human-Connection/issues) please include the number.)
 
 ## Markdown your documentation
 
@@ -117,4 +111,3 @@ TODO: How to modify screenshots in Linux ...
 {% endhint %}
 {% endtab %}
 {% endtabs %}
-

--- a/neo4j/README.md
+++ b/neo4j/README.md
@@ -20,7 +20,7 @@ for an interactive cypher shell and a visualization of the graph.
 
 ## Installation without Docker
 
-Install community edition of [Neo4J]() along with the plugin
+Install the community edition of [Neo4j](https://neo4j.com/) along with the plugin
 [Apoc](https://github.com/neo4j-contrib/neo4j-apoc-procedures) on your system.
 
 To do so, go to [releases](https://neo4j.com/download-center/#releases), choose
@@ -28,7 +28,13 @@ To do so, go to [releases](https://neo4j.com/download-center/#releases), choose
 and unpack the files.
 
 Download [Neo4j Apoc](https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases)
-and drop the file into the `plugins` folder of the just extracted Neo4j-Server.
+and drop the `.jar` file into the `plugins` folder of the just extracted Neo4j-Server.
+
+Then make sure to allow Apoc procedures by adding the following line to your Neo4j configuration \(`conf/neo4j.conf`\):
+
+```
+dbms.security.procedures.unrestricted=apoc.*
+```
 
 ### Alternatives
 
@@ -59,6 +65,6 @@ $ cp .env.template .env
 $ ./db_setup.sh
 ```
 
-Otherwise if you don't have `cypher-shell` available, simply copy the cypher
-statements [from the script](./neo4j/db_setup.sh) and paste the scripts into your
-database [browser frontend](http://localhost:7474).
+Otherwise, if you don't have `cypher-shell` available, copy the cypher
+statements [from the `db_setup.sh` script](https://github.com/Human-Connection/Human-Connection/blob/master/neo4j/db_setup.sh) and paste the scripts into your
+[database browser frontend](http://localhost:7474).

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -41,4 +41,4 @@ All reusable Components \(for example avatar\) should be done inside the [Nitro-
 
 More information can be found here: [https://github.com/Human-Connection/Nitro-Styleguide](https://github.com/Human-Connection/Nitro-Styleguide)
 
-If you need to change something in the styleguide and want to see the effects on the frontend immediately, then we have you covered. You need to clone the styleguide to the parent directory `../Nitro-Styleguide` and run `yarn && yarn run dev`. After that you run `yarn run dev:styleguide` instead of `yarn run dev` and you will see your changes reflected inside the fronten!
+If you need to change something in the styleguide and want to see the effects on the frontend immediately, then we have you covered. You need to clone the styleguide to the parent directory `../Nitro-Styleguide` and run `yarn && yarn run dev`. After that you run `yarn run dev:styleguide` instead of `yarn run dev` and you will see your changes reflected inside the frontend!

--- a/webapp/assets.md
+++ b/webapp/assets.md
@@ -1,8 +1,5 @@
 # ASSETS
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
-This directory contains your un-compiled assets such as LESS, SASS, or JavaScript.
+This directory contains your un-compiled assets such as LESS, SASS, or JavaScript – in our case SCSS styles.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/assets#webpacked).
-

--- a/webapp/components.md
+++ b/webapp/components.md
@@ -1,8 +1,5 @@
 # COMPONENTS
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
 The components directory contains your Vue.js Components.
 
 _Nuxt.js doesn't supercharge these components._
-

--- a/webapp/layouts.md
+++ b/webapp/layouts.md
@@ -1,8 +1,5 @@
 # LAYOUTS
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
 This directory contains your Application Layouts.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/views#layouts).
-

--- a/webapp/middleware.md
+++ b/webapp/middleware.md
@@ -1,8 +1,5 @@
 # MIDDLEWARE
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
-This directory contains your application middleware. The middleware lets you define custom function to be ran before rendering a page or a group of pages \(layouts\).
+This directory contains our application middleware. The middleware lets you define custom functions to be ran before rendering a page or a group of pages \(layouts\).
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/routing#middleware).
-

--- a/webapp/plugins.md
+++ b/webapp/plugins.md
@@ -1,8 +1,5 @@
 # PLUGINS
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
 This directory contains your Javascript plugins that you want to run before mounting the root Vue.js application.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/plugins).
-

--- a/webapp/static.md
+++ b/webapp/static.md
@@ -1,10 +1,9 @@
 # STATIC
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
 This directory contains your static files. Each file inside this directory is mapped to `/`.
 
 Example: `/static/robots.txt` is mapped as `/robots.txt`.
 
-More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/assets#static).
+We use it for images.
 
+More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/assets#static).

--- a/webapp/store.md
+++ b/webapp/store.md
@@ -1,10 +1,7 @@
 # STORE
 
-**This directory is not required, you can delete it if you don't want to use it.**
-
 This directory contains your Vuex Store files. Vuex Store option is implemented in the Nuxt.js framework.
 
-Creating a file in this directory activate the option in the framework automatically.
+Creating a file in this directory activates the option in the framework automatically.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/guide/vuex-store).
-


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2019-07-08T17:50:30Z" title="Monday, July 8th 2019, 7:50:30 pm +02:00">Jul 8, 2019</time>_
_Merged <time datetime="2019-07-09T13:19:53Z" title="Tuesday, July 9th 2019, 3:19:53 pm +02:00">Jul 9, 2019</time>_
---

## 🍰 Pull request
- fixes a few typos
- replaces internal references with absolute links to make them work on GitBook
- updates the "Edit this Documentation" part to work without the "Edit on GitHub" button
- adds information on how to allow Apoc procedures on the Neo4j server
- removes the line "**This directory is not required, you can delete it if you don't want to use it.**" from all webapp docs (I assume they originate from the Nuxt.js templates but since we _are_ using these directories and they can obviously _not_ be removed I thought deleting the line might be less confusing for new contributors. Unless you have a good reason to keep it there?)

### Issues
- None

### Todo
- [ ] Maybe update the [Contribution docs](https://github.com/Human-Connection/Human-Connection/blob/master/CONTRIBUTING.md#development) to include the current mentors and developers?
