### PR TITLE
Follow up of #958

### DIFF
--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -87,7 +87,7 @@
       </ds-container>
     </div>
     <ds-container style="word-break: break-all">
-      <div style="padding: 6rem 2rem 5rem;" :width="{ base: '100%', md: '96%' }">
+      <div class="main-container" :width="{ base: '100%', md: '96%' }">
         <nuxt />
       </div>
     </ds-container>
@@ -214,6 +214,11 @@ export default {
   margin-right: $space-xx-small;
   align-self: center;
   display: inline-flex;
+}
+
+.main-container {
+  padding-top: 6rem;
+  padding-botton: 5rem;
 }
 
 .main-navigation {


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-07-10T00:13:11Z" title="Wednesday, July 10th 2019, 2:13:11 am +02:00">Jul 10, 2019</time>_
_Merged <time datetime="2019-07-10T09:04:23Z" title="Wednesday, July 10th 2019, 11:04:23 am +02:00">Jul 10, 2019</time>_
---

I think I deleted the styling by using bot `:width` and `style`
property. I'm not quite sure if this resolves our problem. Anyways
I don't see a reason for having a right padding so I just removed it.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
