### PR TITLE
Silence codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -95,7 +95,7 @@ coverage:
         #  - master
         #flags:
         #  - integration
-        paths: 
+        paths:
           - backend/  # only include coverage in "backend/" folder
       webapp:  # declare a new status context "frontend"
         against: parent
@@ -127,7 +127,7 @@ coverage:
     #      - integration
     #    paths:
     #      - folder
-    
+
     #changes:
     #  default:
     #    against: parent
@@ -150,20 +150,8 @@ coverage:
 
   #ignore: # files and folders for processing
   #  - tests/*
-  
+
   #fixes:
   #  - "old_path::new_path"
 
-comment:
-  # layout options are quite limited in v4.x - there have been way more options in v1.0
-  layout: reach, diff, flags, files # mostly old options: header, diff, uncovered, reach, files, tree, changes, sunburst, flags
-  behavior: new # default = posts once then update, posts new if delete
-                # once = post once then updates
-                # new = delete old, post new
-                # spammy = post new
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: no        # [yes :: must have a head report to post]
-  branches: null          # branch names that can post comment
-  flags: null
-  paths: null
+comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
 before_install:
   - yarn global add wait-on
   # Install Codecov
-  - yarn global add codecov
   - yarn install
   - cp cypress.env.template.json cypress.env.json
 
@@ -40,7 +39,7 @@ script:
   # Fullstack
   - yarn run cypress:run
   # Coverage
-  - codecov
+  - yarn run codecov
 
 after_success:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,6 @@
       "!**/src/**/?(*.)+(spec|test).js?(x)"
     ],
     "coverageReporters": [
-      "text",
       "lcov"
     ],
     "testMatch": [

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,6 @@
       "!**/?(*.)+(spec|test).js?(x)"
     ],
     "coverageReporters": [
-      "text",
       "lcov"
     ],
     "transform": {


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-07-13T23:47:00Z" title="Sunday, July 14th 2019, 1:47:00 am +02:00">Jul 14, 2019</time>_
_Merged <time datetime="2019-07-15T15:38:42Z" title="Monday, July 15th 2019, 5:38:42 pm +02:00">Jul 15, 2019</time>_
---

## 🍰 Pullrequest
Recently, codecov was spamming our PRs with useless comments. I think this is the moment, when we could disable codecov comments without worrying. There is also reason for disabling the comments even if they would show a valid code coverage: People just get annoyed and start to turn off Github notifications.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
