### PR TITLE
I had enough of `--ignore-engines`

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 
 FROM base as build-and-test
 RUN cp .env.template .env
-RUN yarn install --ignore-engines --production=false --frozen-lockfile --non-interactive
+RUN yarn install --production=false --frozen-lockfile --non-interactive
 RUN yarn run build
 
 FROM base as production

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -76,7 +76,7 @@
     "tiptap-extensions": "~1.26.1",
     "v-tooltip": "~2.0.2",
     "vue-count-to": "~1.0.13",
-    "vue-izitoast": "1.1.2",
+    "vue-izitoast": "roschaefer/vue-izitoast#patch-1",
     "vuex-i18n": "~1.13.1",
     "vue-sweetalert-icons": "~4.1.0",
     "zxcvbn": "^4.4.2"
@@ -97,8 +97,8 @@
     "babel-jest": "~24.8.0",
     "babel-loader": "~8.0.6",
     "babel-preset-vue": "~2.0.2",
-    "css-loader": "~2.1.1",
     "core-js": "~2.6.9",
+    "css-loader": "~2.1.1",
     "eslint": "~5.16.0",
     "eslint-config-prettier": "~6.0.0",
     "eslint-config-standard": "~12.0.0",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -14945,10 +14945,9 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.3.tgz#2756f46cb3258054c5f4723de8ae7e87302a1ccf"
   integrity sha512-KmvZVtmM26BQOMK1rwUZsrqxEGeKiYSZGA7SNWE6uExx8UX/cj9hq2MRV/wWC3Cq6AoeDGk57rL9YMFRel/q+g==
 
-vue-izitoast@1.1.2:
+vue-izitoast@roschaefer/vue-izitoast#patch-1:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vue-izitoast/-/vue-izitoast-1.1.2.tgz#0cf8290f045f8a389ccce4c238836c75a130eb03"
-  integrity sha512-/sNVrYhFg7Moyny5tFNt2e7TTmgPB1xyy04BChKQJkN5r9/D/6vYI7KQWEtG+v9VofnIVg5Em7HXtOL8IOeT7w==
+  resolved "https://codeload.github.com/roschaefer/vue-izitoast/tar.gz/c246fd78b1964c71b1889683379902d8d6284280"
   dependencies:
     izitoast "^1.3.0"
 


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-08-09T11:41:36Z" title="Friday, August 9th 2019, 1:41:36 pm +02:00">Aug 9, 2019</time>_
_Merged <time datetime="2019-08-13T08:46:26Z" title="Tuesday, August 13th 2019, 10:46:26 am +02:00">Aug 13, 2019</time>_
---

The maintainers of https://github.com/arthurvasconcelos/vue-izitoast are
not extremely responsive, so I decided to point our package to my own
fork.

This makes the flag `--ignore-engines` obsolete.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
