### PR TITLE
Fix `Cannot read property countUser of null`

### DIFF
--- a/webapp/components/CountTo.vue
+++ b/webapp/components/CountTo.vue
@@ -2,7 +2,7 @@
   <span>
     <no-ssr placeholder="0" tag="span">
       <count-to
-        :start-val="lastEndVal || startVal"
+        :start-val="startVal"
         :end-val="endVal"
         :duration="duration"
         :autoplay="autoplay"
@@ -24,24 +24,6 @@ export default {
     duration: { type: Number, default: 3000 },
     autoplay: { type: Boolean, default: true },
     separator: { type: String, default: '.' },
-  },
-  data() {
-    return {
-      lastEndVal: null,
-      isReady: false,
-    }
-  },
-  watch: {
-    endVal(endVal) {
-      if (this.isReady && this.startVal === 0 && !this.lastEndVal) {
-        this.lastEndVal = this.endVal
-      }
-    },
-  },
-  mounted() {
-    setTimeout(() => {
-      this.isReady = true
-    }, 500)
   },
 }
 </script>

--- a/webapp/pages/admin/index.vue
+++ b/webapp/pages/admin/index.vue
@@ -7,7 +7,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.users')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countUsers || 0" />
+                  <hc-count-to :end-val="statistics.countUsers || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -16,7 +16,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.posts')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countPosts || 0" />
+                  <hc-count-to :end-val="statistics.countPosts || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -30,7 +30,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countComments || 0" />
+                  <hc-count-to :end-val="statistics.countComments || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -44,7 +44,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countNotifications || 0" />
+                  <hc-count-to :end-val="statistics.countNotifications || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -58,7 +58,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countOrganizations || 0" />
+                  <hc-count-to :end-val="statistics.countOrganizations || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -72,7 +72,7 @@
                 uppercase
               >
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countProjects || 0" />
+                  <hc-count-to :end-val="statistics.countProjects || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -81,7 +81,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.invites')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countInvites || 0" />
+                  <hc-count-to :end-val="statistics.countInvites || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -90,7 +90,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.follows')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countFollows || 0" />
+                  <hc-count-to :end-val="statistics.countFollows || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -99,7 +99,7 @@
             <ds-space margin="small">
               <ds-number :count="0" :label="$t('admin.dashboard.shouts')" size="x-large" uppercase>
                 <no-ssr slot="count">
-                  <hc-count-to :start-val="0" :end-val="statistics.countShouts || 0" />
+                  <hc-count-to :end-val="statistics.countShouts || 0" />
                 </no-ssr>
               </ds-number>
             </ds-space>
@@ -127,9 +127,6 @@ export default {
     isClient() {
       return process.client
     },
-  },
-  mounted() {
-    this.$apollo.queries.statistics.startPolling(5000)
   },
   apollo: {
     statistics: {


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-08-15T22:29:43Z" title="Friday, August 16th 2019, 12:29:43 am +02:00">Aug 16, 2019</time>_
_Merged <time datetime="2019-08-16T12:34:12Z" title="Friday, August 16th 2019, 2:34:12 pm +02:00">Aug 16, 2019</time>_
---

This commit message is a great example of why you should explain
**the reason** of your commit.

When I came across this bug I had a quick look into the code where it
came from. I could see that the bug only happened after a timer and
apparently reverting the biggest part of d84892930295dcfd3f6687fc33c7234446127099
would fix the bug. However I have no idea what the following commit
message means:

```
commit d84892930295dcfd3f6687fc33c7234446127099
Author: Grzegorz Leoniec <greg@app-interactive.de>
Date:   Wed Mar 6 18:45:57 2019 +0100

    Improved countTo component
```

I just don't know why the code is there - like what is it's purpose
@appinteractive? I can only guess: I believe that it's supposed to
update the counters in-place (without starting from 0 everytime).
Because apollo was set to poll the data every second.

Taking that into account I would rather remove this polling feature
completely and have less code and less complexity. Admins can still
refresh the page.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
