### PR TITLE
Fix preview image craziness

### DIFF
--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -1,14 +1,14 @@
 <template>
   <ds-form ref="contributionForm" v-model="form" :schema="formSchema">
     <template slot-scope="{ errors }">
+      <hc-teaser-image :contribution="contribution" @addTeaserImage="addTeaserImage">
+        <img
+          v-if="contribution"
+          class="contribution-image"
+          :src="contribution.image | proxyApiUrl"
+        />
+      </hc-teaser-image>
       <ds-card>
-        <hc-teaser-image :contribution="contribution" @addTeaserImage="addTeaserImage">
-          <img
-            v-if="contribution"
-            class="contribution-image"
-            :src="contribution.image | proxyApiUrl"
-          />
-        </hc-teaser-image>
         <ds-space />
         <hc-user :user="currentUser" :trunc="35" />
         <ds-space />

--- a/webapp/components/TeaserImage/TeaserImage.vue
+++ b/webapp/components/TeaserImage/TeaserImage.vue
@@ -3,6 +3,7 @@
     :options="dropzoneOptions"
     ref="el"
     id="postdropzone"
+    class="ds-card-image"
     :use-custom-slot="true"
     @vdropzone-thumbnail="thumbnail"
     @vdropzone-error="verror"
@@ -10,14 +11,14 @@
     <div class="dz-message">
       <div
         :class="{
-          'hc-attachments-upload-area-post': createAndUpdate,
+          'hc-attachments-upload-area-post': true,
           'hc-attachments-upload-area-update-post': contribution,
         }"
       >
         <slot></slot>
         <div
           :class="{
-            'hc-drag-marker-post': createAndUpdate,
+            'hc-drag-marker-post': true,
             'hc-drag-marker-update-post': contribution,
           }"
         >
@@ -46,7 +47,6 @@ export default {
         previewTemplate: this.template(),
       },
       error: false,
-      createAndUpdate: true,
     }
   },
   watch: {
@@ -102,24 +102,9 @@ export default {
   background-color: $background-color-softest;
 }
 
-#postdropzone img {
-  width: 100%;
-  max-height: 300px;
-  -o-object-fit: cover;
-  object-fit: cover;
-  -o-object-position: center;
-  object-position: center;
-}
-
-@media only screen and (max-width: 400px) {
-  #postdropzone.thumbnail-preview {
-    height: 200px;
-  }
-}
-
-@media only screen and (min-width: 401px) and (max-width: 960px) {
-  #postdropzone.thumbnail-preview {
-    height: 300px;
+@media only screen and (max-width: 960px) {
+  #postdropzone {
+    min-height: 200px;
   }
 }
 

--- a/webapp/components/TeaserImage/TeaserImage.vue
+++ b/webapp/components/TeaserImage/TeaserImage.vue
@@ -75,18 +75,21 @@ export default {
       return ''
     },
     thumbnail: (file, dataUrl) => {
-      let thumbnailElement, contributionImage, uploadArea
+      let thumbnailElement, contributionImage, uploadArea, thumbnailPreview, image
       if (file.previewElement) {
         thumbnailElement = document.querySelectorAll('#postdropzone')[0]
         contributionImage = document.querySelectorAll('.contribution-image')[0]
+        thumbnailPreview = document.querySelectorAll('.thumbnail-preview')[0]
         if (contributionImage) {
           uploadArea = document.querySelectorAll('.hc-attachments-upload-area-update-post')[0]
           uploadArea.removeChild(contributionImage)
           uploadArea.classList.remove('hc-attachments-upload-area-update-post')
         }
-        thumbnailElement.classList.add('image-preview')
-        thumbnailElement.alt = file.name
-        thumbnailElement.style.backgroundImage = 'url("' + dataUrl + '")'
+        image = new Image()
+        image.src = URL.createObjectURL(file)
+        image.classList.add('thumbnail-preview')
+        if (thumbnailPreview) return thumbnailElement.replaceChild(image, thumbnailPreview)
+        thumbnailElement.appendChild(image)
       }
     },
   },
@@ -99,24 +102,23 @@ export default {
   background-color: $background-color-softest;
 }
 
-#postdropzone.image-preview {
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
-  height: auto;
-  transition: all 0.2s ease-out;
-
+#postdropzone img {
   width: 100%;
+  max-height: 300px;
+  -o-object-fit: cover;
+  object-fit: cover;
+  -o-object-position: center;
+  object-position: center;
 }
 
 @media only screen and (max-width: 400px) {
-  #postdropzone.image-preview {
+  #postdropzone.thumbnail-preview {
     height: 200px;
   }
 }
 
 @media only screen and (min-width: 401px) and (max-width: 960px) {
-  #postdropzone.image-preview {
+  #postdropzone.thumbnail-preview {
     height: 300px;
   }
 }

--- a/webapp/pages/post/create.vue
+++ b/webapp/pages/post/create.vue
@@ -1,6 +1,6 @@
 <template>
   <ds-flex :width="{ base: '100%' }" gutter="base">
-    <ds-flex-item :width="{ base: '100%', md: 3 }">
+    <ds-flex-item :width="{ base: '100%', md: 5 }">
       <hc-contribution-form />
     </ds-flex-item>
     <ds-flex-item :width="{ base: '100%', md: 1 }">&nbsp;</ds-flex-item>


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-09-06T11:09:28Z" title="Friday, September 6th 2019, 1:09:28 pm +02:00">Sep 6, 2019</time>_
_Merged <time datetime="2019-09-06T12:02:19Z" title="Friday, September 6th 2019, 2:02:19 pm +02:00">Sep 6, 2019</time>_
---

- depending on the size of the image, the preview looked really blurry
Also, the preview image differed from the image on the PostCard

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #1199 
before `PR`
![Screenshot from 2019-09-06 12-21-27](https://user-images.githubusercontent.com/26943915/64421044-f2e5c500-d0a0-11e9-9b64-932d3da574d5.png)
after `PR`
![Screenshot from 2019-09-06 12-52-07](https://user-images.githubusercontent.com/26943915/64422799-38a48c80-d0a5-11e9-8209-1b34c200c08b.png)
PostCard.vue
![Screenshot from 2019-09-06 12-52-23](https://user-images.githubusercontent.com/26943915/64422823-49550280-d0a5-11e9-941e-df25e53bd8b4.png)

I also made the ContributionForm the same width as the PostCard.vue to keep them consistent