### PR TITLE
Fix test by setting value of the mocked hashtag

### DIFF
--- a/webapp/pages/index.spec.js
+++ b/webapp/pages/index.spec.js
@@ -88,6 +88,8 @@ describe('PostIndex', () => {
     })
 
     it('clears the search when the filter menu emits clearSearch', () => {
+      mocks.$route.query.hashtag = '#samplehashtag'
+      wrapper = Wrapper()
       wrapper.find(FilterMenu).vm.$emit('clearSearch')
       expect(wrapper.vm.hashtag).toBeNull()
     })


### PR DESCRIPTION
> [<img alt="aonomike" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/aonomike) **Authored by [aonomike](https://github.com/aonomike)**
_<time datetime="2019-09-09T13:26:56Z" title="Monday, September 9th 2019, 3:26:56 pm +02:00">Sep 9, 2019</time>_
_Merged <time datetime="2019-09-09T15:17:45Z" title="Monday, September 9th 2019, 5:17:45 pm +02:00">Sep 9, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
- The test wasnt testing anything as the hashtag value was defaulting to null
- Fixed by setting value of hashtag to a string and then testing if the clearSearch works
