### PR TITLE
Fix bug where short comments scrub links

### DIFF
--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -40,12 +40,12 @@
       </div>
       <div v-show="!openEditCommentMenu">
         <content-viewer
-          v-if="comment.content.length < 180"
+          v-if="comment.content.length < 400"
           :content="comment.content"
           class="padding-left"
         />
         <div
-          v-show="comment.content !== comment.contentExcerpt && comment.content.length > 180"
+          v-show="comment.content !== comment.contentExcerpt && comment.content.length > 400"
           class="show-more-or-less-div"
         >
           <content-viewer

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -27,8 +27,6 @@
           />
         </client-only>
       </ds-space>
-
-      <ds-space margin-bottom="small" />
       <div v-if="openEditCommentMenu">
         <hc-comment-form
           :update="true"
@@ -59,7 +57,11 @@
             </a>
           </span>
         </div>
-        <content-viewer v-if="!isCollapsed" :content="comment.content" class="padding-left" />
+        <content-viewer
+          v-if="!isCollapsed"
+          :content="comment.content"
+          class="padding-left text-align-left"
+        />
         <div class="show-more-or-less-div">
           <span class="show-more-or-less">
             <a v-if="!isCollapsed" @click="isCollapsed = !isCollapsed" class="padding-left">
@@ -180,12 +182,11 @@ export default {
 div.show-more-or-less-div {
   text-align: right;
   margin-right: 20px;
-  margin-top: -12px;
 }
 
 span.show-more-or-less {
   display: block;
-  margin: 10px 20px;
+  margin: 0px 20px;
   cursor: pointer;
 }
 </style>


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-09-19T17:19:52Z" title="Thursday, September 19th 2019, 7:19:52 pm +02:00">Sep 19, 2019</time>_
_Merged <time datetime="2019-09-21T11:20:52Z" title="Saturday, September 21st 2019, 1:20:52 pm +02:00">Sep 21, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
the comments are still strange cause they have a height of like `200px` 
maybe @alina-beck can help :pray: 
or I can keep playing...
