### PR TITLE
Fix links to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks so much for thinking of contributing to the Human Connection project, we 
 
 ## Getting Set Up
 
-Instructions for how to install all the necessary software can be found in our [documentation](https://docs.human-connection.org/nitro/)
+Instructions for how to install all the necessary software can be found in our [documentation](https://docs.human-connection.org/human-connection/)
 
 We recommend that new folks should ideally work together with an existing developer. Please join our discord instance to chat with developers or just ask them in tickets in [Zenhub](https://app.zenhub.com/workspaces/human-connection-nitro-5c0154ecc699f60fc92cf11f/boards?repos=152252353):
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Logins:
 
 ## Documentation
 
-Learn how to set up a local development environment in our [Docs](https://docs.human-connection.org/nitro).
+Learn how to set up a local development environment in our [Docs](https://docs.human-connection.org/human-connection/).
 
 ## Translations
 


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-04-12T14:27:35Z" title="Friday, April 12th 2019, 4:27:35 pm +02:00">Apr 12, 2019</time>_
_Merged <time datetime="2019-04-12T16:06:35Z" title="Friday, April 12th 2019, 6:06:35 pm +02:00">Apr 12, 2019</time>_
---

## Pullrequest
I changed the root of the docs URL at gitbook to https://docs.human-connection.org/human-connection/

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [x] Go to https://docs.human-connection.org/human-connection/v/docs_fix_link/

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
