### PR TITLE
Revert logout.vue

### DIFF
--- a/webapp/pages/logout.vue
+++ b/webapp/pages/logout.vue
@@ -11,11 +11,11 @@
           margin-bottom="xxx-small"
           centered
         >
-          <hc-image
+          <img
             style="width: 200px;"
-            :image-props="imageProps"
+            src="/img/sign-up/onourjourney.png"
             alt="Human Connection"
-          />
+          >
         </ds-space>
         <ds-space
           style="text-align: center;"
@@ -36,17 +36,8 @@
 </template>
 
 <script>
-import HcImage from '~/components/Image'
 export default {
-  components: {
-    HcImage
-  },
   layout: 'blank',
-  computed: {
-    imageProps() {
-      return { src: '/img/sign-up/onourjourney.png' }
-    }
-  },
   async beforeCreate() {
     await this.$store.dispatch('auth/logout')
     this.$router.replace('/')


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-05-10T13:40:49Z" title="Friday, May 10th 2019, 3:40:49 pm +02:00">May 10, 2019</time>_
_Merged <time datetime="2019-05-13T10:40:02Z" title="Monday, May 13th 2019, 12:40:02 pm +02:00">May 13, 2019</time>_
---

For any static image URL we don't need to use `<hc-image>`. The assets
will be served from the frontend container. I did not anticipate that we
have a lot of static images in the frontend when I said "You can replace
every image with the `<hc-image>` component".

@aonomike: In the future you can make some screenshots and post them in the PR
and ask for help.

@ulfgebhardt: Yes, it would have been safer not to merge the PR. We
might run into the danger of forgetting things like this.

## Pullrequest
<!-- Describe the Pullrequest. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- [X] None

### Checklist
<!-- Anything important to be thought of when deploying?
- [ ] Env-Variables adjustment needed
- [ ] Breaking/critical change
-->
- [X] None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected. -->
<!-- Maintainers will check the Tests
- [ ] Test1
- [ ] Test2
-->
- [X] None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
