### PR TITLE
Don't remove middlewares in production

### DIFF
--- a/backend/src/middleware/index.js
+++ b/backend/src/middleware/index.js
@@ -1,42 +1,63 @@
-import activityPubMiddleware from './activityPubMiddleware'
-import passwordMiddleware from './passwordMiddleware'
-import softDeleteMiddleware from './softDeleteMiddleware'
-import sluggifyMiddleware from './sluggifyMiddleware'
-import fixImageUrlsMiddleware from './fixImageUrlsMiddleware'
-import excerptMiddleware from './excerptMiddleware'
-import dateTimeMiddleware from './dateTimeMiddleware'
-import xssMiddleware from './xssMiddleware'
-import permissionsMiddleware from './permissionsMiddleware'
-import userMiddleware from './userMiddleware'
-import includedFieldsMiddleware from './includedFieldsMiddleware'
-import orderByMiddleware from './orderByMiddleware'
-import validationMiddleware from './validation'
-import notificationsMiddleware from './notifications'
+import activityPub from './activityPubMiddleware'
+import password from './passwordMiddleware'
+import softDelete from './softDeleteMiddleware'
+import sluggify from './sluggifyMiddleware'
+import fixImageUrls from './fixImageUrlsMiddleware'
+import excerpt from './excerptMiddleware'
+import dateTime from './dateTimeMiddleware'
+import xss from './xssMiddleware'
+import permissions from './permissionsMiddleware'
+import user from './userMiddleware'
+import includedFields from './includedFieldsMiddleware'
+import orderBy from './orderByMiddleware'
+import validation from './validation'
+import notifications from './notifications'
 
 export default schema => {
-  let middleware = [
-    passwordMiddleware,
-    dateTimeMiddleware,
-    validationMiddleware,
-    sluggifyMiddleware,
-    excerptMiddleware,
-    notificationsMiddleware,
-    xssMiddleware,
-    fixImageUrlsMiddleware,
-    softDeleteMiddleware,
-    userMiddleware,
-    includedFieldsMiddleware,
-    orderByMiddleware,
+  const middlewares = {
+    permissions: permissions,
+    activityPub: activityPub,
+    password: password,
+    dateTime: dateTime,
+    validation: validation,
+    sluggify: sluggify,
+    excerpt: excerpt,
+    notifications: notifications,
+    xss: xss,
+    fixImageUrls: fixImageUrls,
+    softDelete: softDelete,
+    user: user,
+    includedFields: includedFields,
+    orderBy: orderBy,
+  }
+
+  let order = [
+    'permissions',
+    'activityPub',
+    'password',
+    'dateTime',
+    'validation',
+    'sluggify',
+    'excerpt',
+    'notifications',
+    'xss',
+    'fixImageUrls',
+    'softDelete',
+    'user',
+    'includedFields',
+    'orderBy',
   ]
 
   // add permisions middleware at the first position (unless we're seeding)
-  // NOTE: DO NOT SET THE PERMISSION FLAT YOUR SELF
   if (process.env.NODE_ENV !== 'production') {
-    const DISABLED_MIDDLEWARES = process.env.DISABLED_MIDDLEWARES || ''
-    const disabled = DISABLED_MIDDLEWARES.split(',')
-    if (!disabled.includes('activityPub')) middleware.unshift(activityPubMiddleware)
-    if (!disabled.includes('permissions'))
-      middleware.unshift(permissionsMiddleware.generate(schema))
+    let disabledMiddlewares = process.env.DISABLED_MIDDLEWARES || ''
+    disabledMiddlewares = disabledMiddlewares.split(',')
+    order = order.filter(key => {
+      return !disabledMiddlewares.includes(key)
+    })
+    /* eslint-disable-next-line no-console */
+    console.log(`Warning: "${disabledMiddlewares}" middlewares have been disabled.`)
   }
-  return middleware
+
+  return order.map(key => middlewares[key])
 }


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-03T12:16:58Z" title="Monday, June 3rd 2019, 2:16:58 pm +02:00">Jun 3, 2019</time>_
_Merged <time datetime="2019-06-03T17:27:34Z" title="Monday, June 3rd 2019, 7:27:34 pm +02:00">Jun 3, 2019</time>_
---

@ulfgebhardt thank you for pointing out! That was a terrible bug.

@Mastercuber FYI: Activity Pub middleware was disabled on production. The RSA keys on staging must have been those that we seeded locally in development environment and dumped+uploaded to kubernetes.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
