### PR TITLE
269 filter by followed users backend part

### DIFF
--- a/backend/src/middleware/filterBubble/filterBubble.js
+++ b/backend/src/middleware/filterBubble/filterBubble.js
@@ -1,0 +1,12 @@
+import replaceParams from './replaceParams'
+
+const replaceFilterBubbleParams = async (resolve, root, args, context, resolveInfo) => {
+  args = await replaceParams(args, context)
+  return resolve(root, args, context, resolveInfo)
+}
+
+export default {
+  Query: {
+    Post: replaceFilterBubbleParams,
+  },
+}

--- a/backend/src/middleware/filterBubble/filterBubble.spec.js
+++ b/backend/src/middleware/filterBubble/filterBubble.spec.js
@@ -65,7 +65,7 @@ describe('FilterBubble middleware', () => {
 
     describe('filtering for posts of followed users only', () => {
       it('returns only posts authored by followed users', async () => {
-        const query = '{ Post( filterBubble: { author: followed }) { title } }'
+        const query = '{ Post( filterBubble: { author: following }) { title } }'
         const expected = {
           Post: [{ title: 'This is the post of a followed user' }],
         }

--- a/backend/src/middleware/filterBubble/filterBubble.spec.js
+++ b/backend/src/middleware/filterBubble/filterBubble.spec.js
@@ -1,0 +1,76 @@
+import { GraphQLClient } from 'graphql-request'
+import { host, login } from '../../jest/helpers'
+import Factory from '../../seed/factories'
+
+const factory = Factory()
+
+const currentUserParams = {
+  email: 'you@example.org',
+  name: 'This is you',
+  password: '1234',
+}
+const followedAuthorParams = {
+  id: 'u2',
+  email: 'followed@example.org',
+  name: 'Followed User',
+  password: '1234',
+}
+const randomAuthorParams = {
+  email: 'someone@example.org',
+  name: 'Someone else',
+  password: 'else',
+}
+
+beforeEach(async () => {
+  await Promise.all([
+    factory.create('User', currentUserParams),
+    factory.create('User', followedAuthorParams),
+    factory.create('User', randomAuthorParams),
+  ])
+  const [asYourself, asFollowedUser, asSomeoneElse] = await Promise.all([
+    Factory().authenticateAs(currentUserParams),
+    Factory().authenticateAs(followedAuthorParams),
+    Factory().authenticateAs(randomAuthorParams),
+  ])
+  await asYourself.follow({ id: 'u2', type: 'User' })
+  await asFollowedUser.create('Post', { title: 'This is the post of a followed user' })
+  await asSomeoneElse.create('Post', { title: 'This is some random post' })
+})
+
+afterEach(async () => {
+  await factory.cleanDatabase()
+})
+
+describe('FilterBubble middleware', () => {
+  describe('given an authenticated user', () => {
+    let authenticatedClient
+
+    beforeEach(async () => {
+      const headers = await login(currentUserParams)
+      authenticatedClient = new GraphQLClient(host, { headers })
+    })
+
+    describe('no filter bubble', () => {
+      it('returns all posts', async () => {
+        const query = '{ Post( filterBubble: {}) { title } }'
+        const expected = {
+          Post: [
+            { title: 'This is some random post' },
+            { title: 'This is the post of a followed user' },
+          ],
+        }
+        await expect(authenticatedClient.request(query)).resolves.toEqual(expected)
+      })
+    })
+
+    describe('filtering for posts of followed users only', () => {
+      it('returns only posts authored by followed users', async () => {
+        const query = '{ Post( filterBubble: { author: followed }) { title } }'
+        const expected = {
+          Post: [{ title: 'This is the post of a followed user' }],
+        }
+        await expect(authenticatedClient.request(query)).resolves.toEqual(expected)
+      })
+    })
+  })
+})

--- a/backend/src/middleware/filterBubble/replaceParams.js
+++ b/backend/src/middleware/filterBubble/replaceParams.js
@@ -1,7 +1,13 @@
+import { UserInputError } from 'apollo-server'
+
 export default async function replaceParams(args, context) {
   const { author = 'all' } = args.filterBubble || {}
+  const { user } = context
 
   if (author === 'followed') {
+    if (!user)
+      throw new UserInputError("You are unauthenticated - I don't know your followed users")
+
     const session = context.driver.session()
     let { records } = await session.run(
       'MATCH(followed:User)<-[:FOLLOWS]-(u {id: $userId}) RETURN followed.id',

--- a/backend/src/middleware/filterBubble/replaceParams.js
+++ b/backend/src/middleware/filterBubble/replaceParams.js
@@ -4,9 +4,9 @@ export default async function replaceParams(args, context) {
   const { author = 'all' } = args.filterBubble || {}
   const { user } = context
 
-  if (author === 'followed') {
+  if (author === 'following') {
     if (!user)
-      throw new UserInputError("You are unauthenticated - I don't know your followed users")
+      throw new UserInputError("You are unauthenticated - I don't know any users you are following.")
 
     const session = context.driver.session()
     let { records } = await session.run(

--- a/backend/src/middleware/filterBubble/replaceParams.js
+++ b/backend/src/middleware/filterBubble/replaceParams.js
@@ -1,0 +1,23 @@
+export default async function replaceParams(args, context) {
+  const { author = 'all' } = args.filterBubble || {}
+
+  if (author === 'followed') {
+    const session = context.driver.session()
+    let { records } = await session.run(
+      'MATCH(followed:User)<-[:FOLLOWS]-(u {id: $userId}) RETURN followed.id',
+      { userId: context.user.id },
+    )
+    const followedIds = records.map(record => record.get('followed.id'))
+
+    // carefully override `id_in`
+    args.filter = args.filter || {}
+    args.filter.author = args.filter.author || {}
+    args.filter.author.id_in = followedIds
+
+    session.close()
+  }
+
+  delete args.filterBubble
+
+  return args
+}

--- a/backend/src/middleware/filterBubble/replaceParams.js
+++ b/backend/src/middleware/filterBubble/replaceParams.js
@@ -6,7 +6,9 @@ export default async function replaceParams(args, context) {
 
   if (author === 'following') {
     if (!user)
-      throw new UserInputError("You are unauthenticated - I don't know any users you are following.")
+      throw new UserInputError(
+        "You are unauthenticated - I don't know any users you are following.",
+      )
 
     const session = context.driver.session()
     let { records } = await session.run(

--- a/backend/src/middleware/filterBubble/replaceParams.spec.js
+++ b/backend/src/middleware/filterBubble/replaceParams.spec.js
@@ -75,7 +75,7 @@ describe('replaceParams', () => {
 
         it('makes database calls', async () => {
           await action()
-          expect(run).toHaveBeenCalled()
+          expect(run).toHaveBeenCalledTimes(1)
         })
 
         describe('given any additional filter args', () => {

--- a/backend/src/middleware/filterBubble/replaceParams.spec.js
+++ b/backend/src/middleware/filterBubble/replaceParams.spec.js
@@ -38,9 +38,9 @@ describe('replaceParams', () => {
         context.user = null
       })
 
-      describe('{ filterBubble: { author: followed } }', () => {
+      describe('{ filterBubble: { author: following } }', () => {
         it('throws error', async () => {
-          args = { filterBubble: { author: 'followed' } }
+          args = { filterBubble: { author: 'following' } }
           await expect(action()).rejects.toThrow('You are unauthenticated')
         })
       })
@@ -63,9 +63,9 @@ describe('replaceParams', () => {
         context.user = { id: 'u4711' }
       })
 
-      describe('{ filterBubble: { author: followed } }', () => {
+      describe('{ filterBubble: { author: following } }', () => {
         beforeEach(() => {
-          args = { filterBubble: { author: 'followed' } }
+          args = { filterBubble: { author: 'following' } }
         })
 
         it('returns args object with resolved ids of followed users', async () => {

--- a/backend/src/middleware/filterBubble/replaceParams.spec.js
+++ b/backend/src/middleware/filterBubble/replaceParams.spec.js
@@ -1,0 +1,99 @@
+import replaceParams from './replaceParams.js'
+
+describe('replaceParams', () => {
+  let args
+  let context
+  let run
+
+  let action = () => {
+    return replaceParams(args, context)
+  }
+
+  beforeEach(() => {
+    args = {}
+    run = jest.fn().mockResolvedValue({
+      records: [{ get: () => 1 }, { get: () => 2 }, { get: () => 3 }],
+    })
+    context = {
+      user: { id: 'u4711' },
+      driver: {
+        session: () => {
+          return {
+            run,
+            close: () => {},
+          }
+        },
+      },
+    }
+  })
+
+  describe('given any additional filter args', () => {
+    describe('merges', () => {
+      it('empty filter object', async () => {
+        args = { filter: {}, filterBubble: { author: 'followed' } }
+        const expected = { filter: { author: { id_in: [1, 2, 3] } } }
+        await expect(action()).resolves.toEqual(expected)
+      })
+
+      it('filter.title', async () => {
+        args = { filter: { title: 'bla' }, filterBubble: { author: 'followed' } }
+        const expected = { filter: { title: 'bla', author: { id_in: [1, 2, 3] } } }
+        await expect(action()).resolves.toEqual(expected)
+      })
+
+      it('filter.author', async () => {
+        args = { filter: { author: { name: 'bla' } }, filterBubble: { author: 'followed' } }
+        const expected = { filter: { author: { name: 'bla', id_in: [1, 2, 3] } } }
+        await expect(action()).resolves.toEqual(expected)
+      })
+    })
+  })
+
+  describe('args == ', () => {
+    describe('{}', () => {
+      it('does not crash', async () => {
+        await expect(action()).resolves.toEqual({})
+      })
+    })
+
+    describe('{ filterBubble: { author: followed } }', () => {
+      beforeEach(() => {
+        args = { filterBubble: { author: 'followed' } }
+      })
+
+      it('returns args object with resolved ids of followed users', async () => {
+        const expected = { filter: { author: { id_in: [1, 2, 3] } } }
+        await expect(action()).resolves.toEqual(expected)
+      })
+
+      it('makes database calls', async () => {
+        await action()
+        expect(run).toHaveBeenCalled()
+      })
+    })
+
+    describe('{ filterBubble: { } }', () => {
+      it('removes filterBubble param', async () => {
+        const expected = {}
+        await expect(action()).resolves.toEqual(expected)
+      })
+
+      it('does not make database calls', async () => {
+        await action()
+        expect(run).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('{ filterBubble: { author: all } }', () => {
+      it('removes filterBubble param', async () => {
+        const expected = {}
+        await expect(action()).resolves.toEqual(expected)
+      })
+
+      it('does not make database calls', async () => {
+        await action()
+        expect(run).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/backend/src/middleware/filterBubble/replaceParams.spec.js
+++ b/backend/src/middleware/filterBubble/replaceParams.spec.js
@@ -15,7 +15,6 @@ describe('replaceParams', () => {
       records: [{ get: () => 1 }, { get: () => 2 }, { get: () => 3 }],
     })
     context = {
-      user: { id: 'u4711' },
       driver: {
         session: () => {
           return {
@@ -27,28 +26,6 @@ describe('replaceParams', () => {
     }
   })
 
-  describe('given any additional filter args', () => {
-    describe('merges', () => {
-      it('empty filter object', async () => {
-        args = { filter: {}, filterBubble: { author: 'followed' } }
-        const expected = { filter: { author: { id_in: [1, 2, 3] } } }
-        await expect(action()).resolves.toEqual(expected)
-      })
-
-      it('filter.title', async () => {
-        args = { filter: { title: 'bla' }, filterBubble: { author: 'followed' } }
-        const expected = { filter: { title: 'bla', author: { id_in: [1, 2, 3] } } }
-        await expect(action()).resolves.toEqual(expected)
-      })
-
-      it('filter.author', async () => {
-        args = { filter: { author: { name: 'bla' } }, filterBubble: { author: 'followed' } }
-        const expected = { filter: { author: { name: 'bla', id_in: [1, 2, 3] } } }
-        await expect(action()).resolves.toEqual(expected)
-      })
-    })
-  })
-
   describe('args == ', () => {
     describe('{}', () => {
       it('does not crash', async () => {
@@ -56,43 +33,96 @@ describe('replaceParams', () => {
       })
     })
 
-    describe('{ filterBubble: { author: followed } }', () => {
+    describe('unauthenticated user', () => {
       beforeEach(() => {
-        args = { filterBubble: { author: 'followed' } }
+        context.user = null
       })
 
-      it('returns args object with resolved ids of followed users', async () => {
-        const expected = { filter: { author: { id_in: [1, 2, 3] } } }
-        await expect(action()).resolves.toEqual(expected)
+      describe('{ filterBubble: { author: followed } }', () => {
+        it('throws error', async () => {
+          args = { filterBubble: { author: 'followed' } }
+          await expect(action()).rejects.toThrow('You are unauthenticated')
+        })
       })
 
-      it('makes database calls', async () => {
-        await action()
-        expect(run).toHaveBeenCalled()
-      })
-    })
+      describe('{ filterBubble: { author: all } }', () => {
+        it('removes filterBubble param', async () => {
+          const expected = {}
+          await expect(action()).resolves.toEqual(expected)
+        })
 
-    describe('{ filterBubble: { } }', () => {
-      it('removes filterBubble param', async () => {
-        const expected = {}
-        await expect(action()).resolves.toEqual(expected)
-      })
-
-      it('does not make database calls', async () => {
-        await action()
-        expect(run).not.toHaveBeenCalled()
+        it('does not make database calls', async () => {
+          await action()
+          expect(run).not.toHaveBeenCalled()
+        })
       })
     })
 
-    describe('{ filterBubble: { author: all } }', () => {
-      it('removes filterBubble param', async () => {
-        const expected = {}
-        await expect(action()).resolves.toEqual(expected)
+    describe('authenticated user', () => {
+      beforeEach(() => {
+        context.user = { id: 'u4711' }
       })
 
-      it('does not make database calls', async () => {
-        await action()
-        expect(run).not.toHaveBeenCalled()
+      describe('{ filterBubble: { author: followed } }', () => {
+        beforeEach(() => {
+          args = { filterBubble: { author: 'followed' } }
+        })
+
+        it('returns args object with resolved ids of followed users', async () => {
+          const expected = { filter: { author: { id_in: [1, 2, 3] } } }
+          await expect(action()).resolves.toEqual(expected)
+        })
+
+        it('makes database calls', async () => {
+          await action()
+          expect(run).toHaveBeenCalled()
+        })
+
+        describe('given any additional filter args', () => {
+          describe('merges', () => {
+            it('empty filter object', async () => {
+              args.filter = {}
+              const expected = { filter: { author: { id_in: [1, 2, 3] } } }
+              await expect(action()).resolves.toEqual(expected)
+            })
+
+            it('filter.title', async () => {
+              args.filter = { title: 'bla' }
+              const expected = { filter: { title: 'bla', author: { id_in: [1, 2, 3] } } }
+              await expect(action()).resolves.toEqual(expected)
+            })
+
+            it('filter.author', async () => {
+              args.filter = { author: { name: 'bla' } }
+              const expected = { filter: { author: { name: 'bla', id_in: [1, 2, 3] } } }
+              await expect(action()).resolves.toEqual(expected)
+            })
+          })
+        })
+      })
+
+      describe('{ filterBubble: { } }', () => {
+        it('removes filterBubble param', async () => {
+          const expected = {}
+          await expect(action()).resolves.toEqual(expected)
+        })
+
+        it('does not make database calls', async () => {
+          await action()
+          expect(run).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('{ filterBubble: { author: all } }', () => {
+        it('removes filterBubble param', async () => {
+          const expected = {}
+          await expect(action()).resolves.toEqual(expected)
+        })
+
+        it('does not make database calls', async () => {
+          await action()
+          expect(run).not.toHaveBeenCalled()
+        })
       })
     })
   })

--- a/backend/src/middleware/index.js
+++ b/backend/src/middleware/index.js
@@ -13,6 +13,7 @@ import includedFields from './includedFieldsMiddleware'
 import orderBy from './orderByMiddleware'
 import validation from './validation'
 import notifications from './notifications'
+import filterBubble from './filterBubble/filterBubble'
 
 export default schema => {
   const middlewares = {
@@ -30,11 +31,13 @@ export default schema => {
     user: user,
     includedFields: includedFields,
     orderBy: orderBy,
+    filterBubble: filterBubble,
   }
 
   let order = [
     'permissions',
     'activityPub',
+    'filterBubble',
     'password',
     'dateTime',
     'validation',

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -1,3 +1,18 @@
+enum FilterBubbleAuthorEnum {
+  followed
+  all
+}
+
+input FilterBubble {
+  author: FilterBubbleAuthorEnum
+}
+
+type Query {
+  Post(
+    filterBubble: FilterBubble
+  ): [Post]
+}
+
 type Post {
   id: ID!
   activityId: String

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -1,5 +1,5 @@
 enum FilterBubbleAuthorEnum {
-  followed
+  following
   all
 }
 

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -9,6 +9,28 @@ input FilterBubble {
 
 type Query {
   Post(
+    id: ID
+    activityId: String
+    objectId: String
+    title: String
+    slug: String
+    content: String
+    contentExcerpt: String
+    image: String
+    imageUpload: Upload
+    visibility: Visibility
+    deleted: Boolean
+    disabled: Boolean
+    createdAt: String
+    updatedAt: String
+    commentsCount: Int
+    shoutedCount: Int
+    shoutedByCurrentUser: Boolean
+    _id: String
+    first: Int
+    offset: Int
+    orderBy: [_PostOrdering]
+    filter: _PostFilter
     filterBubble: FilterBubble
   ): [Post]
 }


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-03T18:02:54Z" title="Monday, June 3rd 2019, 8:02:54 pm +02:00">Jun 3, 2019</time>_
_Merged <time datetime="2019-06-05T20:31:38Z" title="Wednesday, June 5th 2019, 10:31:38 pm +02:00">Jun 5, 2019</time>_
---

## 🍰 Pullrequest
This is the backend part for #269. It can be merged independently.

With this PR the backend accepts an optional input parameter for `Post` query: It's called `filterBubble` and has currently two options: ~`{ author: followed }`~ `{ author: following }` or `{ author: all }`.

![Screenshot - 2019-06-03T195824 383](https://user-images.githubusercontent.com/2110676/58823530-319b5780-863a-11e9-8064-dd12f423862f.png)


versus

![Screenshot - 2019-06-03T195903 512](https://user-images.githubusercontent.com/2110676/58823536-34964800-863a-11e9-91d5-a1ca0d65a787.png)



I'm doing my best in the test setup to minimize those tests that do HTTP calls.


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
