### PR TITLE
Turn off $root listeners in beforeDestroy

### DIFF
--- a/webapp/components/Editor/index.vue
+++ b/webapp/components/Editor/index.vue
@@ -323,6 +323,7 @@ export default {
     })
   },
   beforeDestroy() {
+    this.$root.$off('changeLanguage')
     this.editor.destroy()
   },
   methods: {

--- a/webapp/components/comments/CommentList/index.vue
+++ b/webapp/components/comments/CommentList/index.vue
@@ -54,6 +54,9 @@ export default {
       this.refetchPostComments()
     })
   },
+  beforeDestroy() {
+    this.$root.$off('refetchPostComments')
+  },
   methods: {
     refetchPostComments() {
       if (this.$apollo.queries.Post) {


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-06-14T17:04:08Z" title="Friday, June 14th 2019, 7:04:08 pm +02:00">Jun 14, 2019</time>_
_Merged <time datetime="2019-06-15T11:51:55Z" title="Saturday, June 15th 2019, 1:51:55 pm +02:00">Jun 15, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #804 

long-term we want to avoid these types of events, but in the short-term, or where necessary, we should be turning these off in a `beforeDestroy` lifecycle method