### PR TITLE
Bugfix: Signup email was missing email query param

### DIFF
--- a/backend/src/middleware/email/templates/signup.js
+++ b/backend/src/middleware/email/templates/signup.js
@@ -11,6 +11,7 @@ export const signupTemplate = options => {
   } = options
   const actionUrl = new URL('/registration/create-user-account', CONFIG.CLIENT_URI)
   actionUrl.searchParams.set('nonce', nonce)
+  actionUrl.searchParams.set('email', email)
 
   return {
     to: email,


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-07-12T12:32:03Z" title="Friday, July 12th 2019, 2:32:03 pm +02:00">Jul 12, 2019</time>_
_Merged <time datetime="2019-07-15T11:35:58Z" title="Monday, July 15th 2019, 1:35:58 pm +02:00">Jul 15, 2019</time>_
---

## 🍰 Pullrequest
Together with @victorrms2 I tried out the "Signup users as admin" feature and we ran into this.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
