### PR TITLE
Add memory limits to neo4j deployment

### DIFF
--- a/deployment/human-connection/deployment-neo4j.yaml
+++ b/deployment/human-connection/deployment-neo4j.yaml
@@ -25,13 +25,20 @@
         - name: nitro-neo4j
           image: humanconnection/neo4j:latest
           imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "1G"
+            limits:
+              memory: "2G"
           env:
           - name: NEO4J_apoc_import_file_enabled
             value: "true"
           - name: NEO4J_dbms_memory_pagecache_size
-            value: 1G
+            value: "490M"
           - name: NEO4J_dbms_memory_heap_max__size
-            value: 1G
+            value: "500M"
+          - name: NEO4J_dbms_memory_heap_initial__size
+            value: "500M"
           - name: NEO4J_dbms_security_procedures_unrestricted
             value: "algo.*,apoc.*"
           envFrom:


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-08-26T10:44:59Z" title="Monday, August 26th 2019, 12:44:59 pm +02:00">Aug 26, 2019</time>_
_Merged <time datetime="2019-08-27T08:22:48Z" title="Tuesday, August 27th 2019, 10:22:48 am +02:00">Aug 27, 2019</time>_
---

I cannot increase the memory above "2G" without getting an error that no
node has capacity for it. So I believe we have to change the kubernetes
cluster if we want to assign more memory to neo4j.

The other settings were suggested to me by [neo4j-admin memrec](https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-memrec/).

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
