### PR TITLE
Refactor createdAt to use DateTime and be adding at insertion in the database 

### DIFF
--- a/backend/src/middleware/dateTimeMiddleware.js
+++ b/backend/src/middleware/dateTimeMiddleware.js
@@ -1,7 +1,3 @@
-const setCreatedAt = (resolve, root, args, context, info) => {
-  args.createdAt = new Date().toISOString()
-  return resolve(root, args, context, info)
-}
 const setUpdatedAt = (resolve, root, args, context, info) => {
   args.updatedAt = new Date().toISOString()
   return resolve(root, args, context, info)
@@ -9,7 +5,6 @@ const setUpdatedAt = (resolve, root, args, context, info) => {
 
 export default {
   Mutation: {
-    CreateComment: setCreatedAt,
     UpdateUser: setUpdatedAt,
     UpdatePost: setUpdatedAt,
     UpdateComment: setUpdatedAt,

--- a/backend/src/middleware/dateTimeMiddleware.js
+++ b/backend/src/middleware/dateTimeMiddleware.js
@@ -9,7 +9,6 @@ const setUpdatedAt = (resolve, root, args, context, info) => {
 
 export default {
   Mutation: {
-    CreatePost: setCreatedAt,
     CreateComment: setCreatedAt,
     UpdateUser: setUpdatedAt,
     UpdatePost: setUpdatedAt,

--- a/backend/src/middleware/includedFieldsMiddleware.js
+++ b/backend/src/middleware/includedFieldsMiddleware.js
@@ -24,6 +24,6 @@ const includeFieldsRecursively = includedFields => {
 }
 
 export default {
-  Query: includeFieldsRecursively(['id', 'createdAt', 'disabled', 'deleted']),
-  Mutation: includeFieldsRecursively(['id', 'createdAt', 'disabled', 'deleted']),
+  Query: includeFieldsRecursively(['id', 'disabled', 'deleted']),
+  Mutation: includeFieldsRecursively(['id', 'disabled', 'deleted']),
 }

--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -57,18 +57,13 @@ const notifyUsers = async (label, id, idsOfUsers, reason, context) => {
       break
     }
   }
-  const transactionRes = await session.run(cypher, {
+  await session.run(cypher, {
     label,
     id,
     idsOfUsers,
     reason,
   })
   session.close()
-
-  const [notification] = transactionRes.records.map(record => {
-    return record.get('notification')
-  })
-  return notification
 }
 
 const handleContentDataOfPost = async (resolve, root, args, context, resolveInfo) => {

--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -26,8 +26,7 @@ const notifyUsers = async (label, id, idsOfUsers, reason, context) => {
         AND NOT (user)<-[:BLOCKED]-(author)
         MERGE (post)-[notification:NOTIFIED {reason: $reason}]->(user)
         SET notification.read = FALSE
-        SET notification.created_at = datetime()
-        RETURN notification {.read, .reason, created_at: { formatted: toString(notification.created_at) }} as notification
+        SET notification.createdAt = datetime()
       `
       break
     }
@@ -40,11 +39,7 @@ const notifyUsers = async (label, id, idsOfUsers, reason, context) => {
         AND NOT (user)<-[:BLOCKED]-(postAuthor)
         MERGE (comment)-[notification:NOTIFIED {reason: $reason}]->(user)
         SET notification.read = FALSE
-        SET notification.created_at = datetime()
-        RETURN notification {.read, 
-          .reason, 
-          created_at: { formatted: toString(notification.created_at) }} 
-          AS notification
+        SET notification.createdAt = datetime()
       `
       break
     }
@@ -57,11 +52,7 @@ const notifyUsers = async (label, id, idsOfUsers, reason, context) => {
         AND NOT (author)<-[:BLOCKED]-(user)
         MERGE (comment)-[notification:NOTIFIED {reason: $reason}]->(user)
         SET notification.read = FALSE
-        SET notification.created_at = datetime()
-        RETURN notification {.read, 
-          .reason, 
-          created_at: { formatted: toString(notification.created_at) }} 
-          AS notification 
+        SET notification.createdAt = datetime()
       `
       break
     }

--- a/backend/src/middleware/notifications/notificationsMiddleware.spec.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.spec.js
@@ -77,10 +77,10 @@ afterEach(async () => {
 describe('notifications', () => {
   const notificationQuery = gql`
     query($read: Boolean) {
-      notifications(read: $read, orderBy: created_at_desc) {
+      notifications(read: $read, orderBy: createdAt_desc) {
         read
         reason
-        created_at {
+        createdAt {
           formatted
         }
         from {
@@ -163,7 +163,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    created_at: { formatted: expect.any(String) },
+                    createdAt: { formatted: expect.any(String) },
                     reason: 'commented_on_post',
                     from: {
                       __typename: 'Comment',
@@ -254,7 +254,7 @@ describe('notifications', () => {
               notifications: [
                 {
                   read: false,
-                  created_at: { formatted: expect.any(String) },
+                  createdAt: { formatted: expect.any(String) },
                   reason: 'mentioned_in_post',
                   from: {
                     __typename: 'Post',
@@ -315,7 +315,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    created_at: { formatted: expect.any(String) },
+                    createdAt: { formatted: expect.any(String) },
                     reason: 'mentioned_in_post',
                     from: {
                       __typename: 'Post',
@@ -423,7 +423,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    created_at: { formatted: expect.any(String) },
+                    createdAt: { formatted: expect.any(String) },
                     reason: 'mentioned_in_comment',
                     from: {
                       __typename: 'Comment',

--- a/backend/src/middleware/notifications/notificationsMiddleware.spec.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.spec.js
@@ -77,10 +77,12 @@ afterEach(async () => {
 describe('notifications', () => {
   const notificationQuery = gql`
     query($read: Boolean) {
-      notifications(read: $read, orderBy: createdAt_desc) {
+      notifications(read: $read, orderBy: created_at_desc) {
         read
         reason
-        createdAt
+        created_at {
+          formatted
+        }
         from {
           __typename
           ... on Post {
@@ -161,7 +163,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    createdAt: expect.any(String),
+                    created_at: { formatted: expect.any(String) },
                     reason: 'commented_on_post',
                     from: {
                       __typename: 'Comment',
@@ -252,7 +254,7 @@ describe('notifications', () => {
               notifications: [
                 {
                   read: false,
-                  createdAt: expect.any(String),
+                  created_at: { formatted: expect.any(String) },
                   reason: 'mentioned_in_post',
                   from: {
                     __typename: 'Post',
@@ -313,7 +315,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    createdAt: expect.any(String),
+                    created_at: { formatted: expect.any(String) },
                     reason: 'mentioned_in_post',
                     from: {
                       __typename: 'Post',
@@ -368,31 +370,6 @@ describe('notifications', () => {
                 expect(readBefore).toEqual(true)
                 expect(readAfter).toEqual(false)
               })
-
-              it('updates the `createdAt` attribute', async () => {
-                await createPostAction()
-                await markAsReadAction()
-                const {
-                  data: {
-                    notifications: [{ createdAt: createdAtBefore }],
-                  },
-                } = await query({
-                  query: notificationQuery,
-                })
-                await updatePostAction()
-                const {
-                  data: {
-                    notifications: [{ createdAt: createdAtAfter }],
-                  },
-                } = await query({
-                  query: notificationQuery,
-                })
-                expect(createdAtBefore).toBeTruthy()
-                expect(Date.parse(createdAtBefore)).toEqual(expect.any(Number))
-                expect(createdAtAfter).toBeTruthy()
-                expect(Date.parse(createdAtAfter)).toEqual(expect.any(Number))
-                expect(createdAtBefore).not.toEqual(createdAtAfter)
-              })
             })
           })
         })
@@ -446,7 +423,7 @@ describe('notifications', () => {
                 notifications: [
                   {
                     read: false,
-                    createdAt: expect.any(String),
+                    created_at: { formatted: expect.any(String) },
                     reason: 'mentioned_in_comment',
                     from: {
                       __typename: 'Comment',

--- a/backend/src/middleware/orderByMiddleware.js
+++ b/backend/src/middleware/orderByMiddleware.js
@@ -5,7 +5,7 @@ const defaultOrderBy = (resolve, root, args, context, resolveInfo) => {
   const newestFirst = {
     kind: 'Argument',
     name: { kind: 'Name', value: 'orderBy' },
-    value: { kind: 'EnumValue', value: 'created_at_desc' },
+    value: { kind: 'EnumValue', value: 'createdAt_desc' },
   }
   const [fieldNode] = copy.fieldNodes
   if (fieldNode) fieldNode.arguments.push(newestFirst)

--- a/backend/src/middleware/orderByMiddleware.js
+++ b/backend/src/middleware/orderByMiddleware.js
@@ -5,7 +5,7 @@ const defaultOrderBy = (resolve, root, args, context, resolveInfo) => {
   const newestFirst = {
     kind: 'Argument',
     name: { kind: 'Name', value: 'orderBy' },
-    value: { kind: 'EnumValue', value: 'createdAt_desc' },
+    value: { kind: 'EnumValue', value: 'created_at_desc' },
   }
   const [fieldNode] = copy.fieldNodes
   if (fieldNode) fieldNode.arguments.push(newestFirst)

--- a/backend/src/middleware/orderByMiddleware.spec.js
+++ b/backend/src/middleware/orderByMiddleware.spec.js
@@ -54,7 +54,7 @@ describe('Query', () => {
         ).resolves.toEqual(expected)
       })
 
-      describe('(orderBy: created_at_asc)', () => {
+      describe('(orderBy: createdAt_asc)', () => {
         it('orders by createdAt ascending', async () => {
           const posts = [
             { title: 'first' },
@@ -67,7 +67,7 @@ describe('Query', () => {
             query({
               query: gql`
                 {
-                  Post(orderBy: created_at_asc) {
+                  Post(orderBy: createdAt_asc) {
                     title
                   }
                 }

--- a/backend/src/middleware/orderByMiddleware.spec.js
+++ b/backend/src/middleware/orderByMiddleware.spec.js
@@ -54,7 +54,7 @@ describe('Query', () => {
         ).resolves.toEqual(expected)
       })
 
-      describe('(orderBy: createdAt_asc)', () => {
+      describe('(orderBy: created_at_asc)', () => {
         it('orders by createdAt ascending', async () => {
           const posts = [
             { title: 'first' },
@@ -67,7 +67,7 @@ describe('Query', () => {
             query({
               query: gql`
                 {
-                  Post(orderBy: createdAt_asc) {
+                  Post(orderBy: created_at_asc) {
                     title
                   }
                 }

--- a/backend/src/models/Comment.js
+++ b/backend/src/models/Comment.js
@@ -2,7 +2,7 @@ import uuid from 'uuid/v4'
 
 module.exports = {
   id: { type: 'string', primary: true, default: uuid },
-  createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
+  created_at: { type: 'datetime', default: () => new Date() },
   updatedAt: {
     type: 'string',
     isoDate: true,
@@ -42,7 +42,7 @@ module.exports = {
         type: 'string',
         valid: ['mentioned_in_post', 'mentioned_in_comment', 'commented_on_post'],
       },
-      createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
+      created_at: { type: 'datetime', default: () => new Date() },
     },
   },
 }

--- a/backend/src/models/Comment.js
+++ b/backend/src/models/Comment.js
@@ -2,7 +2,7 @@ import uuid from 'uuid/v4'
 
 module.exports = {
   id: { type: 'string', primary: true, default: uuid },
-  created_at: { type: 'datetime', default: () => new Date() },
+  createdAt: { type: 'datetime', default: () => new Date() },
   updatedAt: {
     type: 'string',
     isoDate: true,
@@ -42,7 +42,7 @@ module.exports = {
         type: 'string',
         valid: ['mentioned_in_post', 'mentioned_in_comment', 'commented_on_post'],
       },
-      created_at: { type: 'datetime', default: () => new Date() },
+      createdAt: { type: 'datetime', default: () => new Date() },
     },
   },
 }

--- a/backend/src/models/Post.js
+++ b/backend/src/models/Post.js
@@ -34,10 +34,10 @@ module.exports = {
         type: 'string',
         valid: ['mentioned_in_post', 'mentioned_in_comment', 'commented_on_post'],
       },
-      createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
+      created_at: { type: 'datetime', default: () => new Date() },
     },
   },
-  createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
+  created_at: { type: 'datetime', default: () => new Date() },
   updatedAt: {
     type: 'string',
     isoDate: true,

--- a/backend/src/models/Post.js
+++ b/backend/src/models/Post.js
@@ -34,10 +34,10 @@ module.exports = {
         type: 'string',
         valid: ['mentioned_in_post', 'mentioned_in_comment', 'commented_on_post'],
       },
-      created_at: { type: 'datetime', default: () => new Date() },
+      createdAt: { type: 'datetime', default: () => new Date() },
     },
   },
-  created_at: { type: 'datetime', default: () => new Date() },
+  createdAt: { type: 'datetime', default: () => new Date() },
   updatedAt: {
     type: 'string',
     isoDate: true,

--- a/backend/src/schema/resolvers/comments.js
+++ b/backend/src/schema/resolvers/comments.js
@@ -14,11 +14,11 @@ export default {
       let comment
       const createCommentCypher = `
         CREATE (comment:Comment {params})
-        SET comment.created_at = datetime()
+        SET comment.createdAt = datetime()
         WITH comment
         MATCH (post:Post {id: $postId}), (author:User {id: $userId})
         MERGE (post)<-[:COMMENTS]-(comment)<-[:WROTE]-(author)
-        RETURN comment, toString(comment.created_at) as commentCreatedAt`
+        RETURN comment, toString(comment.createdAt) as commentCreatedAt`
 
       const createCommentVariables = { userId: context.user.id, postId, params }
       const session = context.driver.session()
@@ -27,7 +27,7 @@ export default {
         const comments = transactionRes.records.map(record => {
           return {
             ...record.get('comment').properties,
-            created_at: { formatted: record.get('commentCreatedAt') },
+            createdAt: { formatted: record.get('commentCreatedAt') },
           }
         })
         comment = comments[0]

--- a/backend/src/schema/resolvers/comments.js
+++ b/backend/src/schema/resolvers/comments.js
@@ -18,7 +18,7 @@ export default {
         WITH comment
         MATCH (post:Post {id: $postId}), (author:User {id: $userId})
         MERGE (post)<-[:COMMENTS]-(comment)<-[:WROTE]-(author)
-        RETURN comment, toString(comment.createdAt) as commentCreatedAt`
+        RETURN comment, toString(comment.createdAt) AS commentCreatedAt`
 
       const createCommentVariables = { userId: context.user.id, postId, params }
       const session = context.driver.session()

--- a/backend/src/schema/resolvers/notifications.js
+++ b/backend/src/schema/resolvers/notifications.js
@@ -5,7 +5,7 @@ const transformReturnType = record => {
     ...record.get('notification').properties,
     created_at: { formatted: record.get('notificationCreatedAt') },
     from: {
-      __typename: record.get('labels(resource)').find(l => resourceTypes.includes(l)),
+      __typename: record.get('resource').labels.find(l => resourceTypes.includes(l)),
       ...record.get('resource').properties,
       created_at: { formatted: record.get('resourceCreatedAt') },
     },
@@ -48,7 +48,7 @@ export default {
         const cypher = `
         MATCH (resource {deleted: false, disabled: false})-[notification:NOTIFIED]->(user:User {id:$id})
         ${whereClause}
-        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user, labels(resource)
+        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user
         ${orderByClause}
         `
         const result = await session.run(cypher, { id: currentUser.id })
@@ -68,7 +68,7 @@ export default {
         const cypher = `
         MATCH (resource {id: $resourceId})-[notification:NOTIFIED {read: FALSE}]->(user:User {id:$id})
         SET notification.read = TRUE
-        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user, labels(resource)
+        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user
         `
         const result = await session.run(cypher, { resourceId: args.id, id: currentUser.id })
         const notifications = await result.records.map(transformReturnType)

--- a/backend/src/schema/resolvers/notifications.js
+++ b/backend/src/schema/resolvers/notifications.js
@@ -3,11 +3,11 @@ const resourceTypes = ['Post', 'Comment']
 const transformReturnType = record => {
   return {
     ...record.get('notification').properties,
-    created_at: { formatted: record.get('notificationCreatedAt') },
+    createdAt: { formatted: record.get('notificationCreatedAt') },
     from: {
       __typename: record.get('resource').labels.find(l => resourceTypes.includes(l)),
       ...record.get('resource').properties,
-      created_at: { formatted: record.get('resourceCreatedAt') },
+      createdAt: { formatted: record.get('resourceCreatedAt') },
     },
     to: {
       ...record.get('user').properties,
@@ -34,11 +34,11 @@ export default {
           whereClause = ''
       }
       switch (args.orderBy) {
-        case 'created_at_asc':
-          orderByClause = 'ORDER BY notification.created_at ASC'
+        case 'createdAt_asc':
+          orderByClause = 'ORDER BY notification.createdAt ASC'
           break
-        case 'created_at_desc':
-          orderByClause = 'ORDER BY notification.created_at DESC'
+        case 'createdAt_desc':
+          orderByClause = 'ORDER BY notification.createdAt DESC'
           break
         default:
           orderByClause = ''
@@ -48,7 +48,7 @@ export default {
         const cypher = `
         MATCH (resource {deleted: false, disabled: false})-[notification:NOTIFIED]->(user:User {id:$id})
         ${whereClause}
-        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user
+        RETURN resource, toString(notification.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) as notificationCreatedAt, user
         ${orderByClause}
         `
         const result = await session.run(cypher, { id: currentUser.id })
@@ -68,7 +68,7 @@ export default {
         const cypher = `
         MATCH (resource {id: $resourceId})-[notification:NOTIFIED {read: FALSE}]->(user:User {id:$id})
         SET notification.read = TRUE
-        RETURN resource, toString(notification.created_at) AS resourceCreatedAt, notification, toString(notification.created_at) as notificationCreatedAt, user
+        RETURN resource, toString(notification.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) as notificationCreatedAt, user
         `
         const result = await session.run(cypher, { resourceId: args.id, id: currentUser.id })
         const notifications = await result.records.map(transformReturnType)

--- a/backend/src/schema/resolvers/notifications.js
+++ b/backend/src/schema/resolvers/notifications.js
@@ -48,7 +48,7 @@ export default {
         const cypher = `
         MATCH (resource {deleted: false, disabled: false})-[notification:NOTIFIED]->(user:User {id:$id})
         ${whereClause}
-        RETURN resource, toString(notification.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) as notificationCreatedAt, user
+        RETURN resource, toString(resource.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) AS notificationCreatedAt, user
         ${orderByClause}
         `
         const result = await session.run(cypher, { id: currentUser.id })
@@ -68,7 +68,7 @@ export default {
         const cypher = `
         MATCH (resource {id: $resourceId})-[notification:NOTIFIED {read: FALSE}]->(user:User {id:$id})
         SET notification.read = TRUE
-        RETURN resource, toString(notification.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) as notificationCreatedAt, user
+        RETURN resource, toString(resource.createdAt) AS resourceCreatedAt, notification, toString(notification.createdAt) AS notificationCreatedAt, user
         `
         const result = await session.run(cypher, { resourceId: args.id, id: currentUser.id })
         const notifications = await result.records.map(transformReturnType)

--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -28,7 +28,7 @@ beforeAll(() => {
 
 beforeEach(async () => {
   authenticatedUser = null
-  variables = { orderBy: 'created_at_asc' }
+  variables = { orderBy: 'createdAt_asc' }
 })
 
 afterEach(async () => {
@@ -124,7 +124,7 @@ describe('given some notifications', () => {
             }
           }
           read
-          created_at {
+          createdAt {
             formatted
           }
         }
@@ -151,7 +151,7 @@ describe('given some notifications', () => {
                 content: 'You have seen this comment mentioning already',
               },
               read: true,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
             {
               from: {
@@ -160,7 +160,7 @@ describe('given some notifications', () => {
                 content: 'Already seen post mention',
               },
               read: true,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
             {
               from: {
@@ -168,7 +168,7 @@ describe('given some notifications', () => {
                 content: 'You have been mentioned in a comment',
               },
               read: false,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
             {
               from: {
@@ -177,7 +177,7 @@ describe('given some notifications', () => {
                 content: 'You have been mentioned in a post',
               },
               read: false,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
           ]
           await expect(query({ query: notificationQuery, variables })).resolves.toMatchObject({
@@ -197,7 +197,7 @@ describe('given some notifications', () => {
                 content: 'You have been mentioned in a comment',
               },
               read: false,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
             {
               from: {
@@ -206,7 +206,7 @@ describe('given some notifications', () => {
                 content: 'You have been mentioned in a post',
               },
               read: false,
-              created_at: { formatted: expect.any(String) },
+              createdAt: { formatted: expect.any(String) },
             },
           ]
           await expect(
@@ -269,7 +269,7 @@ describe('given some notifications', () => {
             }
           }
           read
-          created_at {
+          createdAt {
             formatted
           }
         }
@@ -323,7 +323,7 @@ describe('given some notifications', () => {
                   content: 'You have been mentioned in a post',
                 },
                 read: true,
-                created_at: { formatted: expect.any(String) },
+                createdAt: { formatted: expect.any(String) },
               },
             })
           })
@@ -360,7 +360,7 @@ describe('given some notifications', () => {
                   content: 'You have been mentioned in a comment',
                 },
                 read: true,
-                created_at: { formatted: expect.any(String) },
+                createdAt: { formatted: expect.any(String) },
               },
             })
           })

--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -48,13 +48,15 @@ describe('given some notifications', () => {
       factory.create('Post', { author, id: 'p1', categoryIds, content: 'Not for you' }),
       factory.create('Post', {
         author,
-        id: 'p2',
+        id: 'already-seen-post',
+        title: 'Already seen post title',
         categoryIds,
         content: 'Already seen post mention',
       }),
       factory.create('Post', {
         author,
-        id: 'p3',
+        id: 'have-been-mentioned',
+        title: 'Have been mentioned',
         categoryIds,
         content: 'You have been mentioned in a post',
       }),
@@ -62,19 +64,19 @@ describe('given some notifications', () => {
     const [comment1, comment2, comment3] = await Promise.all([
       factory.create('Comment', {
         author,
-        postId: 'p3',
+        postId: 'have-been-mentioned',
         id: 'c1',
         content: 'You have seen this comment mentioning already',
       }),
       factory.create('Comment', {
         author,
-        postId: 'p3',
+        postId: 'have-been-mentioned',
         id: 'c2',
         content: 'You have been mentioned in a comment',
       }),
       factory.create('Comment', {
         author,
-        postId: 'p3',
+        postId: 'have-been-mentioned',
         id: 'c3',
         content: 'Somebody else was mentioned in a comment',
       }),
@@ -114,6 +116,7 @@ describe('given some notifications', () => {
           from {
             __typename
             ... on Post {
+              title
               content
             }
             ... on Comment {
@@ -153,6 +156,7 @@ describe('given some notifications', () => {
             {
               from: {
                 __typename: 'Post',
+                title: 'Already seen post title',
                 content: 'Already seen post mention',
               },
               read: true,
@@ -169,6 +173,7 @@ describe('given some notifications', () => {
             {
               from: {
                 __typename: 'Post',
+                title: 'Have been mentioned',
                 content: 'You have been mentioned in a post',
               },
               read: false,
@@ -197,6 +202,7 @@ describe('given some notifications', () => {
             {
               from: {
                 __typename: 'Post',
+                title: 'Have been mentioned',
                 content: 'You have been mentioned in a post',
               },
               read: false,
@@ -226,8 +232,10 @@ describe('given some notifications', () => {
               }
             `
             await expect(
-              mutate({ mutation: deletePostMutation, variables: { id: 'p3' } }),
-            ).resolves.toMatchObject({ data: { DeletePost: { id: 'p3', deleted: true } } })
+              mutate({ mutation: deletePostMutation, variables: { id: 'have-been-mentioned' } }),
+            ).resolves.toMatchObject({
+              data: { DeletePost: { id: 'have-been-mentioned', deleted: true } },
+            })
             authenticatedUser = await user.toJson()
           }
 
@@ -302,7 +310,7 @@ describe('given some notifications', () => {
           beforeEach(async () => {
             variables = {
               ...variables,
-              id: 'p3',
+              id: 'have-been-mentioned',
             }
           })
 
@@ -324,7 +332,7 @@ describe('given some notifications', () => {
             beforeEach(async () => {
               variables = {
                 ...variables,
-                id: 'p2',
+                id: 'already-seen-post',
               }
             })
             it('returns null', async () => {

--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -28,7 +28,7 @@ beforeAll(() => {
 
 beforeEach(async () => {
   authenticatedUser = null
-  variables = { orderBy: 'createdAt_asc' }
+  variables = { orderBy: 'created_at_asc' }
 })
 
 afterEach(async () => {
@@ -81,32 +81,26 @@ describe('given some notifications', () => {
     ])
     await Promise.all([
       post1.relateTo(neighbor, 'notified', {
-        createdAt: '2019-08-29T17:33:48.651Z',
         read: false,
         reason: 'mentioned_in_post',
       }),
       post2.relateTo(user, 'notified', {
-        createdAt: '2019-08-30T17:33:48.651Z',
         read: true,
         reason: 'mentioned_in_post',
       }),
       post3.relateTo(user, 'notified', {
-        createdAt: '2019-08-31T17:33:48.651Z',
         read: false,
         reason: 'mentioned_in_post',
       }),
       comment1.relateTo(user, 'notified', {
-        createdAt: '2019-08-30T15:33:48.651Z',
         read: true,
         reason: 'mentioned_in_comment',
       }),
       comment2.relateTo(user, 'notified', {
-        createdAt: '2019-08-30T19:33:48.651Z',
         read: false,
         reason: 'mentioned_in_comment',
       }),
       comment3.relateTo(neighbor, 'notified', {
-        createdAt: '2019-09-01T17:33:48.651Z',
         read: false,
         reason: 'mentioned_in_comment',
       }),
@@ -127,7 +121,9 @@ describe('given some notifications', () => {
             }
           }
           read
-          createdAt
+          created_at {
+            formatted
+          }
         }
       }
     `
@@ -145,77 +141,77 @@ describe('given some notifications', () => {
 
       describe('no filters', () => {
         it('returns all notifications of current user', async () => {
-          const expected = {
-            data: {
-              notifications: [
-                {
-                  from: {
-                    __typename: 'Comment',
-                    content: 'You have seen this comment mentioning already',
-                  },
-                  read: true,
-                  createdAt: '2019-08-30T15:33:48.651Z',
-                },
-                {
-                  from: {
-                    __typename: 'Post',
-                    content: 'Already seen post mention',
-                  },
-                  read: true,
-                  createdAt: '2019-08-30T17:33:48.651Z',
-                },
-                {
-                  from: {
-                    __typename: 'Comment',
-                    content: 'You have been mentioned in a comment',
-                  },
-                  read: false,
-                  createdAt: '2019-08-30T19:33:48.651Z',
-                },
-                {
-                  from: {
-                    __typename: 'Post',
-                    content: 'You have been mentioned in a post',
-                  },
-                  read: false,
-                  createdAt: '2019-08-31T17:33:48.651Z',
-                },
-              ],
+          const expected = [
+            {
+              from: {
+                __typename: 'Comment',
+                content: 'You have seen this comment mentioning already',
+              },
+              read: true,
+              created_at: { formatted: expect.any(String) },
             },
-          }
-          await expect(query({ query: notificationQuery, variables })).resolves.toMatchObject(
-            expected,
-          )
+            {
+              from: {
+                __typename: 'Post',
+                content: 'Already seen post mention',
+              },
+              read: true,
+              created_at: { formatted: expect.any(String) },
+            },
+            {
+              from: {
+                __typename: 'Comment',
+                content: 'You have been mentioned in a comment',
+              },
+              read: false,
+              created_at: { formatted: expect.any(String) },
+            },
+            {
+              from: {
+                __typename: 'Post',
+                content: 'You have been mentioned in a post',
+              },
+              read: false,
+              created_at: { formatted: expect.any(String) },
+            },
+          ]
+          await expect(query({ query: notificationQuery, variables })).resolves.toMatchObject({
+            data: {
+              notifications: expect.arrayContaining(expected),
+            },
+          })
         })
       })
 
       describe('filter for read: false', () => {
         it('returns only unread notifications of current user', async () => {
-          const expected = expect.objectContaining({
-            data: {
-              notifications: [
-                {
-                  from: {
-                    __typename: 'Comment',
-                    content: 'You have been mentioned in a comment',
-                  },
-                  read: false,
-                  createdAt: '2019-08-30T19:33:48.651Z',
-                },
-                {
-                  from: {
-                    __typename: 'Post',
-                    content: 'You have been mentioned in a post',
-                  },
-                  read: false,
-                  createdAt: '2019-08-31T17:33:48.651Z',
-                },
-              ],
+          const expected = [
+            {
+              from: {
+                __typename: 'Comment',
+                content: 'You have been mentioned in a comment',
+              },
+              read: false,
+              created_at: { formatted: expect.any(String) },
             },
-          })
+            {
+              from: {
+                __typename: 'Post',
+                content: 'You have been mentioned in a post',
+              },
+              read: false,
+              created_at: { formatted: expect.any(String) },
+            },
+          ]
           await expect(
             query({ query: notificationQuery, variables: { ...variables, read: false } }),
-          ).resolves.toEqual(expected)
+          ).resolves.toEqual(
+            expect.objectContaining({
+              data: {
+                notifications: expect.arrayContaining(expected),
+              },
+            }),
+          )
         })
 
         describe('if a resource gets deleted', () => {
@@ -265,7 +261,9 @@ describe('given some notifications', () => {
             }
           }
           read
-          createdAt
+          created_at {
+            formatted
+          }
         }
       }
     `
@@ -317,7 +315,7 @@ describe('given some notifications', () => {
                   content: 'You have been mentioned in a post',
                 },
                 read: true,
-                createdAt: '2019-08-31T17:33:48.651Z',
+                created_at: { formatted: expect.any(String) },
               },
             })
           })
@@ -354,7 +352,7 @@ describe('given some notifications', () => {
                   content: 'You have been mentioned in a comment',
                 },
                 read: true,
-                createdAt: '2019-08-30T19:33:48.651Z',
+                created_at: { formatted: expect.any(String) },
               },
             })
           })

--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -33,7 +33,7 @@ export default {
   Query: {
     Post: async (object, params, context, resolveInfo) => {
       params = await filterForBlockedUsers(params, context)
-      return neo4jgraphql(object, params, context, resolveInfo, true)
+      return neo4jgraphql(object, params, context, resolveInfo, false)
     },
     findPosts: async (object, params, context, resolveInfo) => {
       params = await filterForBlockedUsers(params, context)
@@ -81,7 +81,7 @@ export default {
       params.id = params.id || uuid()
       let post
       const createPostCypher = `CREATE (post:Post {params})
-        SET post.created_at = datetime()
+        SET post.createdAt = datetime()
         WITH post
         MATCH (author:User {id: $userId})
         MERGE (post)<-[:WROTE]-(author)
@@ -89,7 +89,7 @@ export default {
         UNWIND $categoryIds AS categoryId
         MATCH (category:Category {id: categoryId})
         MERGE (post)-[:CATEGORIZED]->(category)
-        RETURN post, toString(post.created_at) as postCreatedAt`
+        RETURN post, toString(post.createdAt) as postCreatedAt`
 
       const createPostVariables = { userId: context.user.id, categoryIds, params }
 
@@ -99,7 +99,7 @@ export default {
         const posts = transactionRes.records.map(record => {
           return {
             ...record.get('post').properties,
-            created_at: { formatted: record.get('postCreatedAt') },
+            createdAt: { formatted: record.get('postCreatedAt') },
           }
         })
         post = posts[0]

--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -79,6 +79,7 @@ export default {
       delete params.categoryIds
       params = await fileUpload(params, { file: 'imageUpload', url: 'image' })
       params.id = params.id || uuid()
+      params.createdAt = params.createdAt || new Date().toISOString()
       let post
 
       const createPostCypher = `CREATE (post:Post {params})

--- a/backend/src/schema/resolvers/posts.js
+++ b/backend/src/schema/resolvers/posts.js
@@ -89,7 +89,7 @@ export default {
         UNWIND $categoryIds AS categoryId
         MATCH (category:Category {id: categoryId})
         MERGE (post)-[:CATEGORIZED]->(category)
-        RETURN post, toString(post.createdAt) as postCreatedAt`
+        RETURN post, toString(post.createdAt) AS postCreatedAt`
 
       const createPostVariables = { userId: context.user.id, categoryIds, params }
 

--- a/backend/src/schema/resolvers/posts.spec.js
+++ b/backend/src/schema/resolvers/posts.spec.js
@@ -35,6 +35,7 @@ const createPostMutation = gql`
       author {
         name
       }
+      createdAt
     }
   }
 `
@@ -293,6 +294,15 @@ describe('CreatePost', () => {
 
     it('`disabled` and `deleted` default to `false`', async () => {
       const expected = { data: { CreatePost: { disabled: false, deleted: false } } }
+      await expect(mutate({ mutation: createPostMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    it('sets createdAt at time of creation', async () => {
+      const expected = {
+        data: { CreatePost: { disabled: false, deleted: false, createdAt: expect.any(String) } },
+      }
       await expect(mutate({ mutation: createPostMutation, variables })).resolves.toMatchObject(
         expected,
       )

--- a/backend/src/schema/resolvers/posts.spec.js
+++ b/backend/src/schema/resolvers/posts.spec.js
@@ -35,7 +35,7 @@ const createPostMutation = gql`
       author {
         name
       }
-      created_at {
+      createdAt {
         formatted
       }
     }
@@ -307,7 +307,7 @@ describe('CreatePost', () => {
           CreatePost: {
             disabled: false,
             deleted: false,
-            created_at: { formatted: expect.any(String) },
+            createdAt: { formatted: expect.any(String) },
           },
         },
       }

--- a/backend/src/schema/resolvers/posts.spec.js
+++ b/backend/src/schema/resolvers/posts.spec.js
@@ -35,7 +35,9 @@ const createPostMutation = gql`
       author {
         name
       }
-      createdAt
+      created_at {
+        formatted
+      }
     }
   }
 `
@@ -301,7 +303,13 @@ describe('CreatePost', () => {
 
     it('sets createdAt at time of creation', async () => {
       const expected = {
-        data: { CreatePost: { disabled: false, deleted: false, createdAt: expect.any(String) } },
+        data: {
+          CreatePost: {
+            disabled: false,
+            deleted: false,
+            created_at: { formatted: expect.any(String) },
+          },
+        },
       }
       await expect(mutate({ mutation: createPostMutation, variables })).resolves.toMatchObject(
         expected,

--- a/backend/src/schema/resolvers/users/blockedUsers.spec.js
+++ b/backend/src/schema/resolvers/users/blockedUsers.spec.js
@@ -195,7 +195,7 @@ describe('block', () => {
           ])
           postQuery = gql`
             query {
-              Post(orderBy: created_at_asc) {
+              Post(orderBy: createdAt_asc) {
                 id
                 title
                 author {

--- a/backend/src/schema/resolvers/users/blockedUsers.spec.js
+++ b/backend/src/schema/resolvers/users/blockedUsers.spec.js
@@ -195,7 +195,7 @@ describe('block', () => {
           ])
           postQuery = gql`
             query {
-              Post(orderBy: createdAt_asc) {
+              Post(orderBy: created_at_asc) {
                 id
                 title
                 author {

--- a/backend/src/schema/types/type/Comment.gql
+++ b/backend/src/schema/types/type/Comment.gql
@@ -1,33 +1,33 @@
 type Comment {
-  id: ID!
-  activityId: String
-  author: User @relation(name: "WROTE", direction: "IN")
-  content: String!
-  contentExcerpt: String
-  post: Post @relation(name: "COMMENTS", direction: "OUT")
-  createdAt: String
-  updatedAt: String
-  deleted: Boolean
-  disabled: Boolean
-  disabledBy: User @relation(name: "DISABLED", direction: "IN")
+	id: ID!
+	activityId: String
+	author: User @relation(name: "WROTE", direction: "IN")
+	content: String!
+	contentExcerpt: String
+	post: Post @relation(name: "COMMENTS", direction: "OUT")
+	created_at: DateTime
+	updatedAt: String
+	deleted: Boolean
+	disabled: Boolean
+	disabledBy: User @relation(name: "DISABLED", direction: "IN")
 }
 
 type Mutation {
-  CreateComment(
-    id: ID
-    postId: ID!
-    content: String!
-    contentExcerpt: String
-    deleted: Boolean
-    disabled: Boolean
-    createdAt: String
-  ): Comment
-  UpdateComment(
-    id: ID!
-    content: String!
-    contentExcerpt: String
-    deleted: Boolean
-    disabled: Boolean
-  ): Comment
-  DeleteComment(id: ID!): Comment
+	CreateComment(
+	id: ID
+	postId: ID!
+	content: String!
+	contentExcerpt: String
+	deleted: Boolean
+	disabled: Boolean
+	createdAt: String
+	): Comment
+	UpdateComment(
+	id: ID!
+	content: String!
+	contentExcerpt: String
+	deleted: Boolean
+	disabled: Boolean
+	): Comment
+	DeleteComment(id: ID!): Comment
 }

--- a/backend/src/schema/types/type/Comment.gql
+++ b/backend/src/schema/types/type/Comment.gql
@@ -1,33 +1,32 @@
 type Comment {
-	id: ID!
-	activityId: String
-	author: User @relation(name: "WROTE", direction: "IN")
-	content: String!
-	contentExcerpt: String
-	post: Post @relation(name: "COMMENTS", direction: "OUT")
-	createdAt: DateTime
-	updatedAt: String
-	deleted: Boolean
-	disabled: Boolean
-	disabledBy: User @relation(name: "DISABLED", direction: "IN")
+  id: ID!
+  activityId: String
+  author: User @relation(name: "WROTE", direction: "IN")
+  content: String!
+  contentExcerpt: String
+  post: Post @relation(name: "COMMENTS", direction: "OUT")
+  createdAt: DateTime
+  updatedAt: String
+  deleted: Boolean
+  disabled: Boolean
+  disabledBy: User @relation(name: "DISABLED", direction: "IN")
 }
 
 type Mutation {
-	CreateComment(
-	id: ID
-	postId: ID!
-	content: String!
-	contentExcerpt: String
-	deleted: Boolean
-	disabled: Boolean
-	createdAt: String
-	): Comment
-	UpdateComment(
-	id: ID!
-	content: String!
-	contentExcerpt: String
-	deleted: Boolean
-	disabled: Boolean
-	): Comment
-	DeleteComment(id: ID!): Comment
+  CreateComment(
+    id: ID
+    postId: ID!
+    content: String!
+    contentExcerpt: String
+    deleted: Boolean
+    disabled: Boolean
+    ): Comment
+  UpdateComment(
+    id: ID!
+    content: String!
+    contentExcerpt: String
+    deleted: Boolean
+    disabled: Boolean
+    ): Comment
+  DeleteComment(id: ID!): Comment
 }

--- a/backend/src/schema/types/type/Comment.gql
+++ b/backend/src/schema/types/type/Comment.gql
@@ -5,7 +5,7 @@ type Comment {
 	content: String!
 	contentExcerpt: String
 	post: Post @relation(name: "COMMENTS", direction: "OUT")
-	created_at: DateTime
+	createdAt: DateTime
 	updatedAt: String
 	deleted: Boolean
 	disabled: Boolean

--- a/backend/src/schema/types/type/EMOTED.gql
+++ b/backend/src/schema/types/type/EMOTED.gql
@@ -11,7 +11,6 @@ type EMOTED @relation(name: "EMOTED") {
 
 input _EMOTEDInput {
   emotion: Emotion
-  createdAt: String
   updatedAt: String
 }
 

--- a/backend/src/schema/types/type/NOTIFIED.gql
+++ b/backend/src/schema/types/type/NOTIFIED.gql
@@ -1,28 +1,28 @@
 type NOTIFIED {
-  from: NotificationSource
-  to: User
-  createdAt: String
-  read: Boolean
-  reason: NotificationReason
+	from: NotificationSource
+	to: User
+	created_at: DateTime
+	read: Boolean
+	reason: NotificationReason
 }
 
 union NotificationSource = Post | Comment
 
 enum NotificationOrdering {
-  createdAt_asc
-  createdAt_desc
+	created_at_asc
+	created_at_desc
 }
 
 enum NotificationReason {
-  mentioned_in_post
-  mentioned_in_comment
-  commented_on_post
+	mentioned_in_post
+	mentioned_in_comment
+	commented_on_post
 }
 
 type Query {
-  notifications(read: Boolean, orderBy: NotificationOrdering): [NOTIFIED]
+	notifications(read: Boolean, orderBy: NotificationOrdering): [NOTIFIED]
 }
 
 type Mutation {
-  markAsRead(id: ID!): NOTIFIED
+	markAsRead(id: ID!): NOTIFIED
 }

--- a/backend/src/schema/types/type/NOTIFIED.gql
+++ b/backend/src/schema/types/type/NOTIFIED.gql
@@ -1,7 +1,7 @@
 type NOTIFIED {
 	from: NotificationSource
 	to: User
-	created_at: DateTime
+	createdAt: DateTime
 	read: Boolean
 	reason: NotificationReason
 }
@@ -9,8 +9,8 @@ type NOTIFIED {
 union NotificationSource = Post | Comment
 
 enum NotificationOrdering {
-	created_at_asc
-	created_at_desc
+	createdAt_asc
+	createdAt_desc
 }
 
 enum NotificationReason {

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -1,92 +1,92 @@
 type Post {
-  id: ID!
-  activityId: String
-  objectId: String
-  author: User @relation(name: "WROTE", direction: "IN")
-  title: String!
-  slug: String
-  content: String!
-  contentExcerpt: String
-  image: String
-  imageUpload: Upload
-  visibility: Visibility
-  deleted: Boolean
-  disabled: Boolean
-  disabledBy: User @relation(name: "DISABLED", direction: "IN")
-  createdAt: String
-  updatedAt: String
-  language: String
-  relatedContributions: [Post]!
-    @cypher(
-      statement: """
-      MATCH (this)-[:TAGGED|CATEGORIZED]->(categoryOrTag)<-[:TAGGED|CATEGORIZED]-(post:Post)
-      WHERE NOT post.deleted AND NOT post.disabled
-      RETURN DISTINCT post
-      LIMIT 10
-      """
-    )
+	id: ID!
+	activityId: String
+	objectId: String
+	author: User @relation(name: "WROTE", direction: "IN")
+	title: String!
+	slug: String
+	content: String!
+	contentExcerpt: String
+	image: String
+	imageUpload: Upload
+	visibility: Visibility
+	deleted: Boolean
+	disabled: Boolean
+	disabledBy: User @relation(name: "DISABLED", direction: "IN")
+	created_at: DateTime
+	updatedAt: String
+	language: String
+	relatedContributions: [Post]!
+	@cypher(
+	statement: """
+	MATCH (this)-[: TAGGED|CATEGORIZED]->(categoryOrTag)<-[: TAGGED|CATEGORIZED]-(post: Post)
+	WHERE NOT post.deleted AND NOT post.disabled
+	RETURN DISTINCT post
+	LIMIT 10
+	"""
+	)
 
-  tags: [Tag]! @relation(name: "TAGGED", direction: "OUT")
-  categories: [Category]! @relation(name: "CATEGORIZED", direction: "OUT")
+	tags: [Tag]! @relation(name: "TAGGED", direction: "OUT")
+	categories: [Category]! @relation(name: "CATEGORIZED", direction: "OUT")
 
-  comments: [Comment]! @relation(name: "COMMENTS", direction: "IN")
-  commentsCount: Int!
-    @cypher(
-      statement: "MATCH (this)<-[:COMMENTS]-(r:Comment) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)"
-    )
+	comments: [Comment]! @relation(name: "COMMENTS", direction: "IN")
+	commentsCount: Int!
+	@cypher(
+	statement: "MATCH (this)<-[: COMMENTS]-(r: Comment) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)"
+	)
 
-  shoutedBy: [User]! @relation(name: "SHOUTED", direction: "IN")
-  shoutedCount: Int!
-    @cypher(
-      statement: "MATCH (this)<-[:SHOUTED]-(r:User) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)"
-    )
+	shoutedBy: [User]! @relation(name: "SHOUTED", direction: "IN")
+	shoutedCount: Int!
+	@cypher(
+	statement: "MATCH (this)<-[: SHOUTED]-(r: User) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)"
+	)
 
-  # Has the currently logged in user shouted that post?
-  shoutedByCurrentUser: Boolean!
-    @cypher(
-      statement: "MATCH (this)<-[:SHOUTED]-(u:User {id: $cypherParams.currentUserId}) RETURN COUNT(u) >= 1"
-    )
+	# Has the currently logged in user shouted that post?
+	shoutedByCurrentUser: Boolean!
+	@cypher(
+	statement: "MATCH (this)<-[: SHOUTED]-(u: User { id: $cypherParams.currentUserId}) RETURN COUNT(u) >= 1"
+	)
 
-  emotions: [EMOTED]
-  emotionsCount: Int!
-    @cypher(statement: "MATCH (this)<-[emoted:EMOTED]-(:User) RETURN COUNT(DISTINCT emoted)")
+	emotions: [EMOTED]
+	emotionsCount: Int!
+	@cypher(statement: "MATCH (this)<-[emoted: EMOTED]-(: User) RETURN COUNT(DISTINCT emoted)")
 }
 
 input _PostInput {
-  id: ID!
+	id: ID!
 }
 
 type Mutation {
-  CreatePost(
-    id: ID
-    title: String!
-    slug: String
-    content: String!
-    image: String
-    imageUpload: Upload
-    visibility: Visibility
-    language: String
-    categoryIds: [ID]
-    contentExcerpt: String
-  ): Post
-  UpdatePost(
-    id: ID!
-    title: String!
-    slug: String
-    content: String!
-    contentExcerpt: String
-    image: String
-    imageUpload: Upload
-    visibility: Visibility
-    language: String
-    categoryIds: [ID]
-  ): Post
-  DeletePost(id: ID!): Post
-  AddPostEmotions(to: _PostInput!, data: _EMOTEDInput!): EMOTED
-  RemovePostEmotions(to: _PostInput!, data: _EMOTEDInput!): EMOTED
+	CreatePost(
+	id: ID
+	title: String!
+	slug: String
+	content: String!
+	image: String
+	imageUpload: Upload
+	visibility: Visibility
+	language: String
+	categoryIds: [ID]
+	contentExcerpt: String
+	): Post
+	UpdatePost(
+	id: ID!
+	title: String!
+	slug: String
+	content: String!
+	contentExcerpt: String
+	image: String
+	imageUpload: Upload
+	visibility: Visibility
+	language: String
+	categoryIds: [ID]
+	): Post
+	DeletePost(id: ID!): Post
+	AddPostEmotions(to: _PostInput!, data: _EMOTEDInput!): EMOTED
+	RemovePostEmotions(to: _PostInput!, data: _EMOTEDInput!): EMOTED
 }
 
 type Query {
-  PostsEmotionsCountByEmotion(postId: ID!, data: _EMOTEDInput!): Int!
-  PostsEmotionsByCurrentUser(postId: ID!): [String]
+	PostsEmotionsCountByEmotion(postId: ID!, data: _EMOTEDInput!): Int!
+	PostsEmotionsByCurrentUser(postId: ID!): [String]
 }

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -13,7 +13,7 @@ type Post {
 	deleted: Boolean
 	disabled: Boolean
 	disabledBy: User @relation(name: "DISABLED", direction: "IN")
-	created_at: DateTime
+	createdAt: DateTime
 	updatedAt: String
 	language: String
 	relatedContributions: [Post]!

--- a/webapp/components/Comment.spec.js
+++ b/webapp/components/Comment.spec.js
@@ -68,6 +68,9 @@ describe('Comment.vue', () => {
           id: '2',
           contentExcerpt: 'Hello I am a comment content',
           content: 'Hello I am comment content',
+          createdAt: {
+            formatted: '2019-03-13T11:00:20.835Z',
+          },
         }
       })
 

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -12,7 +12,7 @@
   <div v-else :class="{ comment: true, 'disabled-content': comment.deleted || comment.disabled }">
     <ds-card :id="`commentId-${comment.id}`">
       <ds-space margin-bottom="small">
-        <hc-user :user="author" :date-time="comment.createdAt" />
+        <hc-user :user="author" :date-time="comment.createdAt.formatted" />
         <!-- Content Menu (can open Modals) -->
         <client-only>
           <content-menu
@@ -45,17 +45,21 @@
           style="text-align: right;  margin-right: 20px; margin-top: -12px;"
         >
           <span class="show-more-or-less">
-            <a v-if="isCollapsed" class="padding-left" @click="isCollapsed = !isCollapsed">
-              {{ $t('comment.show.more') }}
-            </a>
+            <a
+              v-if="isCollapsed"
+              class="padding-left"
+              @click="isCollapsed = !isCollapsed"
+            >{{ $t('comment.show.more') }}</a>
           </span>
         </div>
         <content-viewer v-if="!isCollapsed" v-html="comment.content" class="padding-left" />
         <div style="text-align: right;  margin-right: 20px; margin-top: -12px;">
           <span class="show-more-or-less">
-            <a v-if="!isCollapsed" @click="isCollapsed = !isCollapsed" class="padding-left">
-              {{ $t('comment.show.less') }}
-            </a>
+            <a
+              v-if="!isCollapsed"
+              @click="isCollapsed = !isCollapsed"
+              class="padding-left"
+            >{{ $t('comment.show.less') }}</a>
           </span>
         </div>
       </div>

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -45,21 +45,17 @@
           style="text-align: right;  margin-right: 20px; margin-top: -12px;"
         >
           <span class="show-more-or-less">
-            <a
-              v-if="isCollapsed"
-              class="padding-left"
-              @click="isCollapsed = !isCollapsed"
-            >{{ $t('comment.show.more') }}</a>
+            <a v-if="isCollapsed" class="padding-left" @click="isCollapsed = !isCollapsed">
+              {{ $t('comment.show.more') }}
+            </a>
           </span>
         </div>
         <content-viewer v-if="!isCollapsed" v-html="comment.content" class="padding-left" />
         <div style="text-align: right;  margin-right: 20px; margin-top: -12px;">
           <span class="show-more-or-less">
-            <a
-              v-if="!isCollapsed"
-              @click="isCollapsed = !isCollapsed"
-              class="padding-left"
-            >{{ $t('comment.show.less') }}</a>
+            <a v-if="!isCollapsed" @click="isCollapsed = !isCollapsed" class="padding-left">
+              {{ $t('comment.show.less') }}
+            </a>
           </span>
         </div>
       </div>

--- a/webapp/components/CommentList/CommentList.spec.js
+++ b/webapp/components/CommentList/CommentList.spec.js
@@ -27,8 +27,14 @@ describe('CommentList.vue', () => {
       propsData = {
         post: {
           id: 1,
+          createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           comments: [
-            { id: 'comment134', contentExcerpt: 'this is a comment', content: 'this is a comment' },
+            {
+              id: 'comment134',
+              contentExcerpt: 'this is a comment',
+              content: 'this is a comment',
+              createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
+            },
           ],
         },
       }
@@ -42,6 +48,9 @@ describe('CommentList.vue', () => {
       })
       mocks = {
         $t: jest.fn(),
+        $i18n: {
+          locale: () => 'en',
+        },
         $filters: {
           truncate: a => a,
         },
@@ -78,7 +87,7 @@ describe('CommentList.vue', () => {
     })
 
     it('displays comments when there are comments to display', () => {
-      expect(wrapper.find('div.comments').text()).toEqual('this is a comment')
+      expect(wrapper.find('div.comments').text()).toContain('this is a comment')
     })
   })
 })

--- a/webapp/components/PostCard/index.spec.js
+++ b/webapp/components/PostCard/index.spec.js
@@ -31,6 +31,7 @@ describe('PostCard', () => {
           id: 'u1',
         },
         disabled: false,
+        createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
       },
     }
     stubs = {
@@ -41,6 +42,9 @@ describe('PostCard', () => {
       $toast: {
         success: jest.fn(),
         error: jest.fn(),
+      },
+      $i18n: {
+        locale: () => 'en',
       },
       $apollo: {
         mutate: jest.fn().mockResolvedValue({
@@ -116,6 +120,7 @@ describe('PostCard', () => {
       beforeEach(() => {
         propsData.post = {
           title: "It's a title",
+          createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
         }
       })
 

--- a/webapp/components/PostCard/index.vue
+++ b/webapp/components/PostCard/index.vue
@@ -14,7 +14,7 @@
     <!-- Username, Image & Date of Post -->
     <div>
       <client-only>
-        <hc-user :user="post.author" :trunc="35" :date-time="post.createdAt" />
+        <hc-user :user="post.author" :trunc="35" :date-time="post.createdAt.formatted" />
       </client-only>
       <hc-ribbon :text="$t('post.name')" />
     </div>

--- a/webapp/components/SearchInput.spec.js
+++ b/webapp/components/SearchInput.spec.js
@@ -123,7 +123,7 @@ describe('SearchInput.vue', () => {
                 slug: 'trick',
               },
               commentsCount: 0,
-              createdAt: '2019-03-13T11:00:20.835Z',
+              createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
               id: 'p10',
               label: 'Eos aut illo omnis quis eaque et iure aut.',
               shoutedCount: 0,

--- a/webapp/components/SearchInput.vue
+++ b/webapp/components/SearchInput.vue
@@ -58,7 +58,7 @@
                   <ds-flex-item>
                     <ds-text size="small" color="softer" align="right">
                       {{ option.author.name | truncate(32) }} -
-                      {{ option.createdAt | dateTime('dd.MM.yyyy') }}
+                      {{ option.createdAt.formatted | dateTime('dd.MM.yyyy') }}
                     </ds-text>
                   </ds-flex-item>
                 </ds-flex>

--- a/webapp/components/notifications/Notification/Notification.spec.js
+++ b/webapp/components/notifications/Notification/Notification.spec.js
@@ -56,11 +56,13 @@ describe('Notification', () => {
           id: 'comment-1',
           contentExcerpt:
             '<a href="/profile/u123" target="_blank">@dagobert-duck</a> is the best on this comment.',
+          createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           post: {
             title: "It's a post title",
             id: 'post-1',
             slug: 'its-a-title',
             contentExcerpt: 'Post content.',
+            createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           },
         },
       }
@@ -112,6 +114,7 @@ describe('Notification', () => {
           slug: 'its-a-title',
           contentExcerpt:
             '<a href="/profile/u3" target="_blank">@jenny-rostock</a> is the best on this post.',
+          createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
         },
       }
     })
@@ -156,11 +159,13 @@ describe('Notification', () => {
           id: 'comment-1',
           contentExcerpt:
             '<a href="/profile/u123" target="_blank">@dagobert-duck</a> is the best on this comment.',
+          createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           post: {
             title: "It's a post title",
             id: 'post-1',
             slug: 'its-a-title',
             contentExcerpt: 'Post content.',
+            createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           },
         },
       }

--- a/webapp/components/notifications/Notification/Notification.vue
+++ b/webapp/components/notifications/Notification/Notification.vue
@@ -2,7 +2,7 @@
   <ds-space :class="{ read: notification.read, notification: true }" margin-bottom="x-small">
     <client-only>
       <ds-space margin-bottom="x-small">
-        <hc-user :user="from.author" :date-time="from.createdAt" :trunc="35" />
+        <hc-user :user="from.author" :date-time="from.createdAt.formatted" :trunc="35" />
       </ds-space>
       <ds-text class="reason-text-for-test" color="soft">
         {{ $t(`notifications.menu.${notification.reason}`) }}

--- a/webapp/components/notifications/NotificationList/NotificationList.spec.js
+++ b/webapp/components/notifications/NotificationList/NotificationList.spec.js
@@ -34,6 +34,9 @@ describe('NotificationList.vue', () => {
     })
     mocks = {
       $t: jest.fn(),
+      $i18n: {
+        locale: () => 'en',
+      },
     }
     stubs = {
       NuxtLink: RouterLinkStub,
@@ -47,6 +50,7 @@ describe('NotificationList.vue', () => {
             id: 'post-1',
             title: 'some post title',
             slug: 'some-post-title',
+            createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
             contentExcerpt: 'this is a post content',
             author: {
               id: 'john-1',
@@ -63,6 +67,7 @@ describe('NotificationList.vue', () => {
             title: 'another post title',
             slug: 'another-post-title',
             contentExcerpt: 'this is yet another post content',
+            createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
             author: {
               id: 'john-1',
               slug: 'john-doe',

--- a/webapp/graphql/CommentMutations.js
+++ b/webapp/graphql/CommentMutations.js
@@ -9,7 +9,9 @@ export default i18n => {
           id
           contentExcerpt
           content
-          createdAt
+          createdAt {
+            formatted
+          }
           disabled
           deleted
           author {
@@ -38,7 +40,9 @@ export default i18n => {
           id
           contentExcerpt
           content
-          createdAt
+          createdAt {
+            formatted
+          }
           disabled
           deleted
           author {
@@ -58,7 +62,6 @@ export default i18n => {
           id
           contentExcerpt
           content
-          createdAt
           disabled
           deleted
           author {

--- a/webapp/graphql/CommentQuery.js
+++ b/webapp/graphql/CommentQuery.js
@@ -7,7 +7,9 @@ export default app => {
       Comment(postId: $postId) {
         id
         contentExcerpt
-        createdAt
+        createdAt {
+          formatted
+        }
         author {
           id
           slug

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -39,7 +39,9 @@ export const postFragment = lang => gql`
     title
     content
     contentExcerpt
-    createdAt
+    createdAt {
+      formatted
+    }
     disabled
     deleted
     slug
@@ -62,7 +64,9 @@ export const commentFragment = lang => gql`
 
   fragment comment on Comment {
     id
-    createdAt
+    createdAt {
+      formatted
+    }
     disabled
     deleted
     content

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -100,7 +100,9 @@ export const notificationQuery = i18n => {
       notifications(read: false, orderBy: createdAt_desc) {
         read
         reason
-        createdAt
+        createdAt {
+          formatted
+        }
         from {
           __typename
           ... on Post {
@@ -128,7 +130,9 @@ export const markAsReadMutation = i18n => {
       markAsRead(id: $id) {
         read
         reason
-        createdAt
+        createdAt {
+          formatted
+        }
         from {
           __typename
           ... on Post {

--- a/webapp/pages/post/_id/_slug/index.spec.js
+++ b/webapp/pages/post/_id/_slug/index.spec.js
@@ -68,6 +68,7 @@ describe('PostSlug', () => {
             author: {
               id: 'u1',
             },
+            createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
           },
         })
       })

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -6,7 +6,7 @@
       :class="{ 'post-card': true, 'disabled-content': post.disabled }"
     >
       <ds-space margin-bottom="small" />
-      <hc-user :user="post.author" :date-time="post.createdAt" />
+      <hc-user :user="post.author" :date-time="post.createdAt.formatted" />
       <!-- Content Menu (can open Modals) -->
       <client-only>
         <content-menu

--- a/webapp/pages/profile/_id/_slug.spec.js
+++ b/webapp/pages/profile/_id/_slug.spec.js
@@ -27,6 +27,7 @@ describe('ProfileSlug', () => {
       post: {
         id: 'p23',
         name: 'It is a post',
+        createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
       },
       $t: jest.fn(),
       // If you're mocking router, then don't use VueRouter with localVue: https://vue-test-utils.vuejs.org/guides/using-with-vue-router.html
@@ -133,6 +134,7 @@ describe('ProfileSlug', () => {
                 return {
                   ...aPost,
                   id,
+                  createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
                 }
               })
 
@@ -164,6 +166,7 @@ describe('ProfileSlug', () => {
                 return {
                   ...aPost,
                   id,
+                  createdAt: { formatted: '2019-03-13T11:00:20.835Z' },
                 }
               })
 

--- a/webapp/store/search.js
+++ b/webapp/store/search.js
@@ -53,7 +53,9 @@ export const actions = {
               label: title
               value: title
               shoutedCount
-              createdAt
+              createdAt {
+                formatted
+              }
               author {
                 id
                 name


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-09-11T14:21:34Z" title="Wednesday, September 11th 2019, 4:21:34 pm +02:00">Sep 11, 2019</time>_
_Closed <time datetime="2019-09-14T09:07:15Z" title="Saturday, September 14th 2019, 11:07:15 am +02:00">Sep 14, 2019</time>_
---

- not happy with this solution, but it adds a test case, which can be
monitored on every test run to see if we ever have a post created
without createdAt, also it sets createdAt in the CreatePost resolver if
for some reason it didn't get set in the dateTimeMiddleware

- Co-authored-by: Mike Aono <aonomike@gmail.com>

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #1494 

