### PR TITLE
Fix bug where about must not be empty string

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -16,7 +16,7 @@ module.exports = {
   wasInvited: 'boolean',
   wasSeeded: 'boolean',
   locationName: { type: 'string', allow: [null] },
-  about: { type: 'string', allow: [null] },
+  about: { type: 'string', allow: [null, ''] },
   primaryEmail: {
     type: 'relationship',
     relationship: 'PRIMARY_EMAIL',

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -484,6 +484,17 @@ describe('SignupVerification', () => {
             })
           })
 
+          it('allowing the about field to be an empty string', async () => {
+            variables = { ...variables, about: '' }
+            await expect(mutate({ mutation, variables })).resolves.toMatchObject({
+              data: {
+                SignupVerification: expect.objectContaining({
+                  id: expect.any(String),
+                }),
+              },
+            })
+          })
+
           it('marks the EmailAddress as primary', async () => {
             const cypher = `
                 MATCH(email:EmailAddress)<-[:PRIMARY_EMAIL]-(u:User {name: {name}})


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-09-18T11:11:10Z" title="Wednesday, September 18th 2019, 1:11:10 pm +02:00">Sep 18, 2019</time>_
_Merged <time datetime="2019-09-18T12:39:46Z" title="Wednesday, September 18th 2019, 2:39:46 pm +02:00">Sep 18, 2019</time>_
---

- add test case to test this use case since it is the default from our
UI
At the moment people cannot sign up unless they add their `About` property, which is not the desired functionality