### PR TITLE
Remove language toggle from email template

### DIFF
--- a/backend/src/middleware/email/templates/emailVerification.html
+++ b/backend/src/middleware/email/templates/emailVerification.html
@@ -1,10 +1,6 @@
 <!-- Email Body German : BEGIN -->
 <table class="email-german" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
   style="margin: auto;">
-  <tr>
-    <td style="padding: 20px 0; text-align: center">
-    </td>
-  </tr>
 
   <!-- Hero Image, Flush : BEGIN -->
   <tr>

--- a/backend/src/middleware/email/templates/layout.html
+++ b/backend/src/middleware/email/templates/layout.html
@@ -142,60 +142,6 @@
       }
     }
   </style>
-
-  <!-- LANGUAGE TOGGLE -->
-  <style>
-    .toggle+label {
-      display: inline-block;
-      height: 40px;
-      padding: 0 12px;
-      margin-top: 40px;
-      line-height: 38px;
-      font-family: Lato, sans-serif;
-      font-size: 16px;
-      border: 1px solid #cbc7d1;
-      cursor: pointer;
-    }
-
-    .toggle+label:hover {
-      background-color: #bee876;
-    }
-
-    .toggle:checked+label {
-      background-color: #19c243;
-      color: white;
-    }
-
-    .toggle-english+label {
-      border-bottom-right-radius: 50px;
-      border-top-right-radius: 50px;
-      border-left: none;
-      margin-left: -2px;
-    }
-
-    .toggle-german+label {
-      border-bottom-left-radius: 50px;
-      border-top-left-radius: 50px;
-      border-right: none;
-      margin-right: -2px;
-    }
-
-    .toggle-german:checked~table.email-german {
-      display: block;
-    }
-
-    .toggle-german:checked~table.email-english {
-      display: none;
-    }
-
-    .toggle-english:checked~table.email-english {
-      display: block;
-    }
-
-    .toggle-english:checked~table.email-german {
-      display: none;
-    }
-  </style>
 </head>
 
 <body width="100%" style="margin: 0; padding: 0 !important; mso-line-height-rule: exactly; background-color: #f5f4f6;">
@@ -213,13 +159,7 @@
             <td>
       <![endif]-->
 
-      <!-- LANGUAGE TOGGLE -->
-      <input type="radio" name="language" class="toggle toggle-german" style="display: none;" id="toggle-german"
-        checked="checked">
-      <label for="toggle-german">Deutsch</label>
-      <input type="radio" name="language" class="toggle toggle-english" style="display:none;" id="toggle-english">
-      <label for="toggle-english">English</label>
-      <p style="margin: 0;"></p>
+      <p style="color:#19c243; font-style: italic; font-family: Lato, sans-serif; font-size: 16px; padding-top: 20px;">English version below!</p>
 
       {{> content}}
 

--- a/backend/src/middleware/email/templates/resetPassword.html
+++ b/backend/src/middleware/email/templates/resetPassword.html
@@ -1,10 +1,6 @@
 <!-- Email Body German : BEGIN -->
 <table class="email-german" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
   style="margin: auto;">
-  <tr>
-    <td style="padding: 20px 0; text-align: center">
-    </td>
-  </tr>
 
   <!-- Hero Image, Flush : BEGIN -->
   <tr>

--- a/backend/src/middleware/email/templates/signup.html
+++ b/backend/src/middleware/email/templates/signup.html
@@ -1,10 +1,6 @@
 <!-- Email Body German : BEGIN -->
 <table class="email-german" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
   style="margin: auto;">
-  <tr>
-    <td style="padding: 20px 0; text-align: center">
-    </td>
-  </tr>
 
   <!-- Hero Image, Flush : BEGIN -->
   <tr>

--- a/backend/src/middleware/email/templates/wrongAccount.html
+++ b/backend/src/middleware/email/templates/wrongAccount.html
@@ -1,10 +1,6 @@
 <!-- Email Body German : BEGIN -->
 <table class="email-german" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
   style="margin: auto;">
-  <tr>
-    <td style="padding: 20px 0; text-align: center">
-    </td>
-  </tr>
 
   <!-- Hero Image, Flush : BEGIN -->
   <tr>


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2019-10-02T21:15:53Z" title="Wednesday, October 2nd 2019, 11:15:53 pm +02:00">Oct 2, 2019</time>_
_Merged <time datetime="2019-10-03T23:54:01Z" title="Friday, October 4th 2019, 1:54:01 am +02:00">Oct 4, 2019</time>_
---

## 🍰 Pullrequest
removes language toggle from email templates – turns out it's buggy in many webmail clients even with different fallback methods... :(

### Issues
- fixes #1656 
