### PR TITLE
fix invites count calculation for admin dashboard

### DIFF
--- a/backend/src/schema/resolvers/statistics.js
+++ b/backend/src/schema/resolvers/statistics.js
@@ -9,7 +9,7 @@ export default {
           countPosts: 'Post',
           countComments: 'Comment',
           countNotifications: 'NOTIFIED',
-          countInvites: 'InvitationCode',
+          countEmails: 'EmailAddress',
           countFollows: 'FOLLOWS',
           countShouts: 'SHOUTED',
         }
@@ -28,6 +28,11 @@ export default {
           const stat = statistics[mapping[key]]
           response[key] = stat ? stat.toNumber() : 0
         })
+
+        /*
+        * Note: invites count is calculated this way because invitation codes are not in use yet
+        */
+        response.countInvites = response.countEmails - response.countUsers
       } finally {
         session.close()
       }

--- a/backend/src/schema/resolvers/statistics.js
+++ b/backend/src/schema/resolvers/statistics.js
@@ -30,8 +30,8 @@ export default {
         })
 
         /*
-        * Note: invites count is calculated this way because invitation codes are not in use yet
-        */
+         * Note: invites count is calculated this way because invitation codes are not in use yet
+         */
         response.countInvites = response.countEmails - response.countUsers
       } finally {
         session.close()


### PR DESCRIPTION
> [<img alt="vbelolapotkov" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/vbelolapotkov) **Authored by [vbelolapotkov](https://github.com/vbelolapotkov)**
_<time datetime="2019-10-03T09:56:00Z" title="Thursday, October 3rd 2019, 11:56:00 am +02:00">Oct 3, 2019</time>_
_Merged <time datetime="2019-10-03T21:51:17Z" title="Thursday, October 3rd 2019, 11:51:17 pm +02:00">Oct 3, 2019</time>_
---

## 🍰 Pullrequest
This is a workaround solution for counting invites for admin dashboard suggested by @roschaefer in #1633 

### Issues
- fixes #1633 

### Todo
- [X] None
