### PR TITLE
Language will be saved in the database of the user during registration 

### DIFF
--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -109,7 +109,7 @@ module.exports = {
     type: 'boolean',
     default: false,
   },
-  language: {
+  locale: {
     type: 'string',
     allow: [null],
   },

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -108,7 +108,7 @@ module.exports = {
   allowEmbedIframes: {
     type: 'boolean',
     default: false,
-  }, 
+  },
   language: {
     type: 'string',
     allow: [null],

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -108,5 +108,9 @@ module.exports = {
   allowEmbedIframes: {
     type: 'boolean',
     default: false,
+  }, 
+  language: {
+    type: 'string',
+    allow: [null],
   },
 }

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -390,7 +390,7 @@ describe('SignupVerification', () => {
         nonce: $nonce
         about: $about
         termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-        locale: $language
+        locale: $locale
       ) {
         id
         termsAndConditionsAgreedVersion

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -290,8 +290,7 @@ describe('Signup', () => {
 
     it('throws AuthorizationError', async () => {
       await expect(mutate({ mutation, variables })).resolves.toMatchObject({
-        // errors: [{ message: 'Not Authorised!' }],
-        errors: undefined,
+        errors: [{ message: 'Not Authorised!' }],
       })
     })
 

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -381,7 +381,7 @@ describe('SignupVerification', () => {
       $nonce: String!
       $about: String
       $termsAndConditionsAgreedVersion: String!
-      $language: String
+      $locale: String
     ) {
       SignupVerification(
         name: $name
@@ -390,7 +390,7 @@ describe('SignupVerification', () => {
         nonce: $nonce
         about: $about
         termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-        language: $language
+        locale: $language
       ) {
         id
         termsAndConditionsAgreedVersion
@@ -407,7 +407,7 @@ describe('SignupVerification', () => {
         password: '123',
         email: 'john@example.org',
         termsAndConditionsAgreedVersion: '0.1.0',
-        language: 'en',
+        locale: 'en',
       }
     })
 

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -290,7 +290,8 @@ describe('Signup', () => {
 
     it('throws AuthorizationError', async () => {
       await expect(mutate({ mutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        // errors: [{ message: 'Not Authorised!' }],
+        errors: undefined,
       })
     })
 
@@ -381,6 +382,7 @@ describe('SignupVerification', () => {
       $nonce: String!
       $about: String
       $termsAndConditionsAgreedVersion: String!
+      $language: String
     ) {
       SignupVerification(
         name: $name
@@ -389,6 +391,7 @@ describe('SignupVerification', () => {
         nonce: $nonce
         about: $about
         termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
+        language: $language
       ) {
         id
         termsAndConditionsAgreedVersion
@@ -405,6 +408,7 @@ describe('SignupVerification', () => {
         password: '123',
         email: 'john@example.org',
         termsAndConditionsAgreedVersion: '0.1.0',
+        language: 'en',
       }
     })
 

--- a/backend/src/schema/types/type/EmailAddress.gql
+++ b/backend/src/schema/types/type/EmailAddress.gql
@@ -19,6 +19,7 @@ type Mutation {
     locationName: String
     about: String
     termsAndConditionsAgreedVersion: String!
+    language: String
   ): User
   AddEmailAddress(email: String!): EmailAddress
   VerifyEmailAddress(

--- a/backend/src/schema/types/type/EmailAddress.gql
+++ b/backend/src/schema/types/type/EmailAddress.gql
@@ -19,7 +19,7 @@ type Mutation {
     locationName: String
     about: String
     termsAndConditionsAgreedVersion: String!
-    language: String
+    locale: String
   ): User
   AddEmailAddress(email: String!): EmailAddress
   VerifyEmailAddress(

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -29,7 +29,7 @@ type User {
 
 	allowEmbedIframes: Boolean
 
-	language: String
+	locale: String
 
 	friends: [User]! @relation(name: "FRIENDS", direction: "BOTH")
 	friendsCount: Int! @cypher(statement: "MATCH (this)<-[: FRIENDS]->(r: User) RETURN COUNT(DISTINCT r)")
@@ -171,7 +171,7 @@ type Mutation {
 	termsAndConditionsAgreedVersion: String
 	termsAndConditionsAgreedAt: String
 	allowEmbedIframes: Boolean
-	language: String
+	locale: String
 	): User
 
 	DeleteUser(id: ID!, resource: [Deletable]): User

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -29,6 +29,8 @@ type User {
 
 	allowEmbedIframes: Boolean
 
+	language: String
+
 	friends: [User]! @relation(name: "FRIENDS", direction: "BOTH")
 	friendsCount: Int! @cypher(statement: "MATCH (this)<-[: FRIENDS]->(r: User) RETURN COUNT(DISTINCT r)")
 
@@ -169,6 +171,7 @@ type Mutation {
 	termsAndConditionsAgreedVersion: String
 	termsAndConditionsAgreedAt: String
 	allowEmbedIframes: Boolean
+	language: String
 	): User
 
 	DeleteUser(id: ID!, resource: [Deletable]): User

--- a/backend/src/seed/factories/users.js
+++ b/backend/src/seed/factories/users.js
@@ -17,7 +17,7 @@ export default function create() {
         termsAndConditionsAgreedVersion: '0.0.1',
         termsAndConditionsAgreedAt: '2019-08-01T10:47:19.212Z',
         allowEmbedIframes: false,
-        language: 'en',
+        locale: 'en',
       }
       defaults.slug = slugify(defaults.name, { lower: true })
       args = {

--- a/backend/src/seed/factories/users.js
+++ b/backend/src/seed/factories/users.js
@@ -17,6 +17,7 @@ export default function create() {
         termsAndConditionsAgreedVersion: '0.0.1',
         termsAndConditionsAgreedAt: '2019-08-01T10:47:19.212Z',
         allowEmbedIframes: false,
+        language: 'en',
       }
       defaults.slug = slugify(defaults.name, { lower: true })
       args = {

--- a/webapp/components/Registration/CreateUserAccount.spec.js
+++ b/webapp/components/Registration/CreateUserAccount.spec.js
@@ -24,6 +24,9 @@ describe('CreateUserAccount', () => {
         loading: false,
         mutate: jest.fn(),
       },
+      $i18n: {
+        locale: () => 'en',
+      },
     }
     propsData = {}
     stubs = {
@@ -69,12 +72,6 @@ describe('CreateUserAccount', () => {
           }
         })
 
-        it('calls CreateUserAccount graphql mutation', async () => {
-          await action()
-          const expected = expect.objectContaining({ mutation: SignupVerificationMutation })
-          expect(mocks.$apollo.mutate).toHaveBeenCalledWith(expected)
-        })
-
         it('delivers data to backend', async () => {
           await action()
           const expected = expect.objectContaining({
@@ -88,6 +85,12 @@ describe('CreateUserAccount', () => {
               language: 'en',
             },
           })
+          expect(mocks.$apollo.mutate).toHaveBeenCalledWith(expected)
+        })
+
+        it('calls CreateUserAccount graphql mutation', async () => {
+          await action()
+          const expected = expect.objectContaining({ mutation: SignupVerificationMutation })
           expect(mocks.$apollo.mutate).toHaveBeenCalledWith(expected)
         })
 

--- a/webapp/components/Registration/CreateUserAccount.spec.js
+++ b/webapp/components/Registration/CreateUserAccount.spec.js
@@ -85,6 +85,7 @@ describe('CreateUserAccount', () => {
               nonce: '666777',
               password: 'hellopassword',
               termsAndConditionsAgreedVersion: '0.0.2',
+              language: 'en',
             },
           })
           expect(mocks.$apollo.mutate).toHaveBeenCalledWith(expected)

--- a/webapp/components/Registration/CreateUserAccount.spec.js
+++ b/webapp/components/Registration/CreateUserAccount.spec.js
@@ -82,7 +82,7 @@ describe('CreateUserAccount', () => {
               nonce: '666777',
               password: 'hellopassword',
               termsAndConditionsAgreedVersion: '0.0.2',
-              language: 'en',
+              locale: 'en',
             },
           })
           expect(mocks.$apollo.mutate).toHaveBeenCalledWith(expected)

--- a/webapp/components/Registration/CreateUserAccount.vue
+++ b/webapp/components/Registration/CreateUserAccount.vue
@@ -158,7 +158,15 @@ export default {
       try {
         await this.$apollo.mutate({
           mutation: SignupVerificationMutation,
-          variables: { name, password, about, email, nonce, termsAndConditionsAgreedVersion, language },
+          variables: {
+            name,
+            password,
+            about,
+            email,
+            nonce,
+            termsAndConditionsAgreedVersion,
+            language,
+          },
         })
         this.response = 'success'
         setTimeout(() => {

--- a/webapp/components/Registration/CreateUserAccount.vue
+++ b/webapp/components/Registration/CreateUserAccount.vue
@@ -156,7 +156,7 @@ export default {
       const { name, password, about } = this.formData
       const { email, nonce } = this
       const termsAndConditionsAgreedVersion = VERSION
-      const language = this.$i18n.locale()
+      const locale = this.$i18n.locale()
       try {
         await this.$apollo.mutate({
           mutation: SignupVerificationMutation,
@@ -167,7 +167,7 @@ export default {
             email,
             nonce,
             termsAndConditionsAgreedVersion,
-            language,
+            locale,
           },
         })
         this.response = 'success'

--- a/webapp/components/Registration/CreateUserAccount.vue
+++ b/webapp/components/Registration/CreateUserAccount.vue
@@ -154,10 +154,11 @@ export default {
       const { name, password, about } = this.formData
       const { email, nonce } = this
       const termsAndConditionsAgreedVersion = VERSION
+      const language = this.$i18n.locale()
       try {
         await this.$apollo.mutate({
           mutation: SignupVerificationMutation,
-          variables: { name, password, about, email, nonce, termsAndConditionsAgreedVersion },
+          variables: { name, password, about, email, nonce, termsAndConditionsAgreedVersion, language },
         })
         this.response = 'success'
         setTimeout(() => {

--- a/webapp/components/Registration/CreateUserAccount.vue
+++ b/webapp/components/Registration/CreateUserAccount.vue
@@ -70,22 +70,24 @@
             :checked="termsAndConditionsConfirmed"
           />
           <label
-            for="checkbox"
+            for="checkbox0"
             v-html="$t('termsAndConditions.termsAndConditionsConfirmed')"
           ></label>
         </ds-text>
-        <p>
-          <label>
-            <input id="checkbox1" type="checkbox" v-model="dataPrivacy" :checked="dataPrivacy" />
-            <span v-html="$t('components.registration.signup.form.data-privacy')"></span>
-          </label>
-        </p>
-        <p>
-          <label>
-            <input id="checkbox2" type="checkbox" v-model="minimumAge" :checked="minimumAge" />
-            <span v-html="$t('components.registration.signup.form.minimum-age')"></span>
-          </label>
-        </p>
+        <ds-text>
+          <input id="checkbox1" type="checkbox" v-model="dataPrivacy" :checked="dataPrivacy" />
+          <label
+            for="checkbox1"
+            v-html="$t('components.registration.signup.form.data-privacy')"
+          ></label>
+        </ds-text>
+        <ds-text>
+          <input id="checkbox2" type="checkbox" v-model="minimumAge" :checked="minimumAge" />
+          <label
+            for="checkbox2"
+            v-html="$t('components.registration.signup.form.minimum-age')"
+          ></label>
+        </ds-text>
         <ds-button
           style="float: right;"
           icon="check"

--- a/webapp/graphql/Registration.js
+++ b/webapp/graphql/Registration.js
@@ -7,6 +7,7 @@ export const SignupVerificationMutation = gql`
     $password: String!
     $about: String
     $termsAndConditionsAgreedVersion: String!
+    $language: String
   ) {
     SignupVerification(
       nonce: $nonce
@@ -15,6 +16,7 @@ export const SignupVerificationMutation = gql`
       password: $password
       about: $about
       termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
+      language: $language
     ) {
       id
       name

--- a/webapp/graphql/Registration.js
+++ b/webapp/graphql/Registration.js
@@ -7,7 +7,7 @@ export const SignupVerificationMutation = gql`
     $password: String!
     $about: String
     $termsAndConditionsAgreedVersion: String!
-    $language: String
+    $locale: String
   ) {
     SignupVerification(
       nonce: $nonce
@@ -16,7 +16,7 @@ export const SignupVerificationMutation = gql`
       password: $password
       about: $about
       termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-      language: $language
+      language: $locale
     ) {
       id
       name

--- a/webapp/graphql/Registration.js
+++ b/webapp/graphql/Registration.js
@@ -16,7 +16,7 @@ export const SignupVerificationMutation = gql`
       password: $password
       about: $about
       termsAndConditionsAgreedVersion: $termsAndConditionsAgreedVersion
-      language: $locale
+      locale: $locale
     ) {
       id
       name


### PR DESCRIPTION
> [<img alt="ogerly" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/ogerly) **Authored by [ogerly](https://github.com/ogerly)**
_<time datetime="2019-10-16T13:14:20Z" title="Wednesday, October 16th 2019, 3:14:20 pm +02:00">Oct 16, 2019</time>_
_Merged <time datetime="2019-10-18T13:11:05Z" title="Friday, October 18th 2019, 3:11:05 pm +02:00">Oct 18, 2019</time>_
---

## 🍰 Pullrequest
set language will be saved in the database of the user during registration 
eingestellte sprache wird beim registrieren in die datenbank zum user gespeichert 

### issuse
#1929 

### group
dieses Problem ist ein Teil von https://github.com/Human-Connection/Human-Connection/issues/1931

![FireShot Capture 094 - Human Connection - Human Connection - localhost](https://user-images.githubusercontent.com/1324583/66922568-97a3dc80-f027-11e9-8eb4-44813e75f105.png)


![FireShot Capture 093 - bolt___localhost_7687 - Neo4j Browser - localhost](https://user-images.githubusercontent.com/1324583/66922030-8e664000-f026-11e9-9dc1-fb03a853bd0f.png)


 