### PR TITLE
fix: Don't attempt to save locale if not authenticated

### DIFF
--- a/webapp/Dockerfile.maintenance
+++ b/webapp/Dockerfile.maintenance
@@ -1,5 +1,5 @@
 FROM node:12.13.0-alpine as build
-LABEL Description="Web Frontend of the Social Network Human-Connection.org" Vendor="Human-Connection gGmbH" Version="0.0.1" Maintainer="Human-Connection gGmbH (developer@human-connection.org)"
+LABEL Description="Maintenance page of the Social Network Human-Connection.org" Vendor="Human-Connection gGmbH" Version="0.0.1" Maintainer="Human-Connection gGmbH (developer@human-connection.org)"
 
 EXPOSE 3000
 CMD ["yarn", "run", "start"]
@@ -19,6 +19,7 @@ RUN yarn install --production=false --frozen-lockfile --non-interactive
 
 COPY assets assets
 COPY components/LocaleSwitch/ components/LocaleSwitch
+COPY graphql graphql
 COPY components/Dropdown.vue components/Dropdown.vue
 COPY layouts/blank.vue layouts/blank.vue
 COPY locales locales

--- a/webapp/Dockerfile.maintenance
+++ b/webapp/Dockerfile.maintenance
@@ -19,7 +19,6 @@ RUN yarn install --production=false --frozen-lockfile --non-interactive
 
 COPY assets assets
 COPY components/LocaleSwitch/ components/LocaleSwitch
-COPY graphql graphql
 COPY components/Dropdown.vue components/Dropdown.vue
 COPY layouts/blank.vue layouts/blank.vue
 COPY locales locales

--- a/webapp/components/LocaleSwitch/LocaleSwitch.spec.js
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.spec.js
@@ -2,26 +2,43 @@ import { mount, createLocalVue } from '@vue/test-utils'
 import Styleguide from '@human-connection/styleguide'
 import VTooltip from 'v-tooltip'
 import LocaleSwitch from './LocaleSwitch.vue'
+import Vuex from 'vuex'
 
 const localVue = createLocalVue()
 
 localVue.use(Styleguide)
 localVue.use(VTooltip)
+localVue.use(Vuex)
 
 describe('LocaleSwitch.vue', () => {
-  let wrapper
-  let mocks
-  let computed
-  let deutschLanguageItem
+  let wrapper, mocks, computed, deutschLanguageItem, getters
 
   beforeEach(() => {
     mocks = {
       $i18n: {
-        locale: () => 'de',
-        set: jest.fn(),
+        locale: () => 'en',
+        set: jest.fn(locale => locale),
       },
       $t: jest.fn(),
+      $toast: {
+        success: jest.fn(a => a),
+        error: jest.fn(a => a),
+      },
       setPlaceholderText: jest.fn(),
+      $apollo: {
+        mutate: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: {
+              UpdateUser: {
+                locale: 'de',
+              },
+            },
+          })
+          .mockRejectedValueOnce({
+            message: 'Please log in!',
+          }),
+      },
     }
     computed = {
       current: () => {
@@ -40,12 +57,21 @@ describe('LocaleSwitch.vue', () => {
         ]
       },
     }
+    getters = {
+      'auth/user': () => {
+        return { id: 'u35' }
+      },
+    }
   })
 
-  describe('mount', () => {
-    const Wrapper = () => {
-      return mount(LocaleSwitch, { mocks, localVue, computed })
-    }
+  const Wrapper = () => {
+    const store = new Vuex.Store({
+      getters,
+    })
+    return mount(LocaleSwitch, { mocks, localVue, computed, store })
+  }
+
+  describe('with current user', () => {
     beforeEach(() => {
       wrapper = Wrapper()
       wrapper.find('.locale-menu').trigger('click')
@@ -53,8 +79,30 @@ describe('LocaleSwitch.vue', () => {
       deutschLanguageItem.trigger('click')
     })
 
-    it("changes a user's locale", () => {
+    it("sets a user's locale", () => {
       expect(mocks.$i18n.set).toHaveBeenCalledTimes(1)
+    })
+
+    it("updates the user's locale in the database", () => {
+      expect(mocks.$apollo.mutate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('no current user', () => {
+    beforeEach(() => {
+      getters = {
+        'auth/user': () => {
+          return null
+        },
+      }
+      wrapper = Wrapper()
+      wrapper.find('.locale-menu').trigger('click')
+      deutschLanguageItem = wrapper.findAll('li').at(1)
+      deutschLanguageItem.trigger('click')
+    })
+
+    it('does not send a UpdateUser mutation', () => {
+      expect(mocks.$apollo.mutate).not.toHaveBeenCalled()
     })
   })
 })

--- a/webapp/components/LocaleSwitch/LocaleSwitch.vue
+++ b/webapp/components/LocaleSwitch/LocaleSwitch.vue
@@ -33,12 +33,12 @@
 </template>
 
 <script>
+import gql from 'graphql-tag'
 import Dropdown from '~/components/Dropdown'
 import find from 'lodash/find'
 import orderBy from 'lodash/orderBy'
 import locales from '~/locales'
 import { mapGetters, mapMutations } from 'vuex'
-import { localeMutation } from '~/graphql/User.js'
 
 export default {
   components: {
@@ -84,9 +84,17 @@ export default {
       setCurrentUser: 'auth/SET_USER',
     }),
     async updateUserLocale() {
+      if (!this.currentUser || !this.currentUser.id) return null
       try {
         await this.$apollo.mutate({
-          mutation: localeMutation(),
+          mutation: gql`
+            mutation($id: ID!, $locale: String) {
+              UpdateUser(id: $id, locale: $locale) {
+                id
+                locale
+              }
+            }
+          `,
           variables: {
             id: this.currentUser.id,
             locale: this.$i18n.locale(),


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-10-24T09:12:20Z" title="Thursday, October 24th 2019, 11:12:20 am +02:00">Oct 24, 2019</time>_
_Merged <time datetime="2019-10-24T12:22:09Z" title="Thursday, October 24th 2019, 2:22:09 pm +02:00">Oct 24, 2019</time>_
---

~@ogerly the maintenance page needs just two components of the webapp
folder. For that reason we import only these. If you add imports to
`LocaleSwitch` component, you need to copy those files in the
Dockerfile.~

~Please don't merge.~ Maintenance page should not need `graphql` because it's never sending a backend request.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
