### PR TITLE
convert email to lowercase before submitting

### DIFF
--- a/webapp/components/PasswordReset/Request.vue
+++ b/webapp/components/PasswordReset/Request.vue
@@ -68,9 +68,12 @@ export default {
     }
   },
   computed: {
-    submitMessage() {
+    lowercaseEmail() {
       const { email } = this.formData
-      return this.$t('components.password-reset.request.form.submitted', { email })
+      return email.toLowerCase()
+    },
+    submitMessage() {
+      return this.$t('components.password-reset.request.form.submitted', { email: this.lowercaseEmail })
     },
   },
   methods: {
@@ -86,7 +89,7 @@ export default {
           requestPasswordReset(email: $email)
         }
       `
-      const { email } = this.formData
+      const email = this.lowercaseEmail
 
       try {
         await this.$apollo.mutate({ mutation, variables: { email } })


### PR DESCRIPTION
> [<img alt="StephenHogsten" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/StephenHogsten) **Authored by [StephenHogsten](https://github.com/StephenHogsten)**
_<time datetime="2019-10-30T17:56:15Z" title="Wednesday, October 30th 2019, 6:56:15 pm +01:00">Oct 30, 2019</time>_
_Closed <time datetime="2019-11-04T23:57:31Z" title="Tuesday, November 5th 2019, 12:57:31 am +01:00">Nov 5, 2019</time>_
---

Convert user inputted email to lowercase when requesting a password reset

### Issues
- fixes #2057
