### PR TITLE
Add shoutedBy_some to _PostFilter

### DIFF
--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -19,6 +19,7 @@ input _PostFilter {
   title_not_starts_with: String
   title_ends_with: String
   title_not_ends_with: String
+  shoutedBy_some: _UserFilter
   slug: String
   slug_not: String
   slug_in: [String!]


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-11-25T11:37:41Z" title="Monday, November 25th 2019, 12:37:41 pm +01:00">Nov 25, 2019</time>_
_Merged <time datetime="2019-11-25T14:36:39Z" title="Monday, November 25th 2019, 3:36:39 pm +01:00">Nov 25, 2019</time>_
---

- we have a feature that allows users to publicly show their shouts with
their consent. we need this for the filter to work.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #2352 

@roschaefer I believe you removed this from the _PostFilter when you manually added them, but we merged in functionality that requires this filter. please review