### PR TITLE
Improve notification query performance by reducing db calls

### DIFF
--- a/backend/src/schema/resolvers/helpers/databaseLogger.js
+++ b/backend/src/schema/resolvers/helpers/databaseLogger.js
@@ -1,0 +1,15 @@
+import Debug from 'debug'
+const debugCypher = Debug('human-connection:neo4j:cypher')
+const debugStats = Debug('human-connection:neo4j:stats')
+
+export default function log(response) {
+  const { statement, counters, resultConsumedAfter, resultAvailableAfter } = response.summary
+  const { text, parameters } = statement
+  debugCypher('%s', text)
+  debugCypher('%o', parameters)
+  debugStats('%o', counters)
+  debugStats('%o', {
+    resultConsumedAfter: resultConsumedAfter.toNumber(),
+    resultAvailableAfter: resultAvailableAfter.toNumber(),
+  })
+}

--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -184,6 +184,7 @@ describe('given some notifications', () => {
             data: {
               notifications: expect.arrayContaining(expected),
             },
+            errors: undefined,
           })
         })
       })
@@ -233,7 +234,10 @@ describe('given some notifications', () => {
             `
             await expect(
               mutate({ mutation: deletePostMutation, variables: { id: 'p3' } }),
-            ).resolves.toMatchObject({ data: { DeletePost: { id: 'p3', deleted: true } } })
+            ).resolves.toMatchObject({
+              data: { DeletePost: { id: 'p3', deleted: true } },
+              errors: undefined,
+            })
             authenticatedUser = await user.toJson()
           }
 
@@ -242,11 +246,12 @@ describe('given some notifications', () => {
               query({ query: notificationQuery, variables: { ...variables, read: false } }),
             ).resolves.toMatchObject({
               data: { notifications: [expect.any(Object), expect.any(Object)] },
+              errors: undefined,
             })
             await deletePostAction()
             await expect(
               query({ query: notificationQuery, variables: { ...variables, read: false } }),
-            ).resolves.toMatchObject({ data: { notifications: [] } })
+            ).resolves.toMatchObject({ data: { notifications: [] }, errors: undefined })
           })
         })
       })

--- a/backend/src/schema/resolvers/reports.js
+++ b/backend/src/schema/resolvers/reports.js
@@ -106,7 +106,6 @@ export default {
       })
       try {
         const reports = await reportReadTxPromise
-        if (!reports) return []
         return reports
       } finally {
         session.close()
@@ -135,7 +134,6 @@ export default {
       })
       try {
         const filedReports = await readTxPromise
-        if (!filedReports) return []
         filed = filedReports.map(reportedRecord => {
           const { submitter, filed } = reportedRecord
           const relationshipWithNestedAttributes = {

--- a/backend/src/schema/resolvers/reports.spec.js
+++ b/backend/src/schema/resolvers/reports.spec.js
@@ -21,7 +21,6 @@ describe('file a report on a resource', () => {
         id
         createdAt
         updatedAt
-        disable
         closed
         rule
         resource {
@@ -623,7 +622,6 @@ describe('file a report on a resource', () => {
               id: expect.any(String),
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
-              disable: false,
               closed: false,
               resource: {
                 __typename: 'User',
@@ -644,7 +642,6 @@ describe('file a report on a resource', () => {
               id: expect.any(String),
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
-              disable: false,
               closed: false,
               resource: {
                 __typename: 'Post',
@@ -665,7 +662,6 @@ describe('file a report on a resource', () => {
               id: expect.any(String),
               createdAt: expect.any(String),
               updatedAt: expect.any(String),
-              disable: false,
               closed: false,
               resource: {
                 __typename: 'Comment',

--- a/backend/src/schema/resolvers/reports.spec.js
+++ b/backend/src/schema/resolvers/reports.spec.js
@@ -489,7 +489,6 @@ describe('file a report on a resource', () => {
           id
           createdAt
           updatedAt
-          disable
           closed
           resource {
             __typename

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -1,5 +1,15 @@
 import gql from 'graphql-tag'
 
+export const linkableUserFragment = lang => gql`
+  fragment user on User {
+    id
+    slug
+    name
+    avatar
+    disabled
+    deleted
+  }
+`
 export const userFragment = lang => gql`
   fragment user on User {
     id
@@ -32,8 +42,6 @@ export const postCountsFragment = gql`
   }
 `
 export const postFragment = lang => gql`
-  ${userFragment(lang)}
-
   fragment post on Post {
     id
     title
@@ -68,8 +76,6 @@ export const postFragment = lang => gql`
   }
 `
 export const commentFragment = lang => gql`
-  ${userFragment(lang)}
-
   fragment comment on Comment {
     id
     createdAt

--- a/webapp/graphql/PostQuery.js
+++ b/webapp/graphql/PostQuery.js
@@ -1,9 +1,10 @@
 import gql from 'graphql-tag'
-import { postFragment, commentFragment, postCountsFragment } from './Fragments'
+import { userFragment, postFragment, commentFragment, postCountsFragment } from './Fragments'
 
 export default i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${userFragment(lang)}
     ${postFragment(lang)}
     ${postCountsFragment}
     ${commentFragment(lang)}
@@ -23,6 +24,7 @@ export default i18n => {
 export const filterPosts = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${userFragment(lang)}
     ${postFragment(lang)}
     ${postCountsFragment}
 
@@ -38,6 +40,7 @@ export const filterPosts = i18n => {
 export const profilePagePosts = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${userFragment(lang)}
     ${postFragment(lang)}
     ${postCountsFragment}
 
@@ -66,6 +69,7 @@ export const PostsEmotionsByCurrentUser = () => {
 export const relatedContributions = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${userFragment(lang)}
     ${postFragment(lang)}
     ${postCountsFragment}
 

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag'
-import { userFragment, postFragment, commentFragment } from './Fragments'
+import { linkableUserFragment, userFragment, postFragment, commentFragment } from './Fragments'
 
 export default i18n => {
   const lang = i18n.locale().toUpperCase()
@@ -49,6 +49,7 @@ export const minimisedUserQuery = () => {
 export const notificationQuery = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${linkableUserFragment()}
     ${commentFragment(lang)}
     ${postFragment(lang)}
 
@@ -78,6 +79,7 @@ export const notificationQuery = i18n => {
 export const markAsReadMutation = i18n => {
   const lang = i18n.locale().toUpperCase()
   return gql`
+    ${linkableUserFragment()}
     ${commentFragment(lang)}
     ${postFragment(lang)}
 


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-12-10T00:46:32Z" title="Tuesday, December 10th 2019, 1:46:32 am +01:00">Dec 10, 2019</time>_
_Merged <time datetime="2019-12-10T18:26:06Z" title="Tuesday, December 10th 2019, 7:26:06 pm +01:00">Dec 10, 2019</time>_
---

## 🍰 Pullrequest
We had plenty of database calls for our notification query. That could very well be the source of our recent performance issues in the backend.

