### PR TITLE
fix: cypress breaks locally in login step

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -60,7 +60,6 @@ Cypress.Commands.add("login", ({ email, password }) => {
     .as("submitButton")
     .click();
   cy.get(".iziToast-message").should("contain", "You are logged in!");
-  cy.get(".iziToast-close").click();
 });
 
 Cypress.Commands.add("logout", (email, password) => {


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-01-14T12:37:36Z" title="Tuesday, January 14th 2020, 1:37:36 pm +01:00">Jan 14, 2020</time>_
_Merged <time datetime="2020-01-16T18:30:26Z" title="Thursday, January 16th 2020, 7:30:26 pm +01:00">Jan 16, 2020</time>_
---

- We do not need to simulate a user closing the toaster, as this is not
that common of a user interaction, fails intermittently locally, and
costs unnecessary build time

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #2775 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
