### PR TITLE
feat: 🍰 Display User ID On User Profile

### DIFF
--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -24,6 +24,7 @@
         "shouted": "Empfohlen",
         "commented": "Kommentiert",
         "userAnonym": "Anonymus",
+        "userId": "Benutzer-ID",
         "socialMedia": "Wo sonst finde ich",
         "network": {
             "title": "Netzwerk",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -161,6 +161,7 @@
     "shouted": "Shouted",
     "commented": "Commented",
     "userAnonym": "Anonymous",
+    "userId": "User ID",
     "socialMedia": "Where else can I find",
     "network": {
       "title": "Network",

--- a/webapp/pages/profile/_id/_slug.spec.js
+++ b/webapp/pages/profile/_id/_slug.spec.js
@@ -21,12 +21,15 @@ describe('ProfileSlug', () => {
         id: 'p23',
         name: 'It is a post',
       },
-      $t: jest.fn(),
+      $t: jest.fn(a => a),
+      $filters: {
+        date: jest.fn(a => a),
+      },
       // If you're mocking router, then don't use VueRouter with localVue: https://vue-test-utils.vuejs.org/guides/using-with-vue-router.html
       $route: {
         params: {
-          id: '4711',
-          slug: 'john-doe',
+          id: 'f26bc193-605d-4465-994e-c2f328d9db01',
+          slug: 'bob-the-builder',
         },
       },
       $router: {
@@ -63,7 +66,7 @@ describe('ProfileSlug', () => {
           getters: {
             'auth/isModerator': () => false,
             'auth/user': {
-              id: 'u23',
+              id: 'f26bc193-605d-4465-994e-c2f328d9db01',
             },
           },
         }
@@ -75,8 +78,11 @@ describe('ProfileSlug', () => {
           wrapper.setData({
             User: [
               {
-                id: 'u3',
+                id: 'f26bc193-605d-4465-994e-c2f328d9db01',
                 name: 'Bob the builder',
+                slug: 'bob-the-builder',
+                createdAt: '2020-01-23T06:38:58.813Z',
+                about: 'Oh! I am so excited about me and myself …',
                 contributionsCount: 6,
                 shoutedCount: 7,
                 commentedCount: 8,
@@ -87,6 +93,34 @@ describe('ProfileSlug', () => {
 
         it('displays name of the user', () => {
           expect(wrapper.text()).toContain('Bob the builder')
+        })
+
+        it('displays slug of the user', () => {
+          expect(wrapper.text()).toContain('@bob-the-builder')
+        })
+
+        describe('member since', () => {
+          it('displays description identifier', () => {
+            expect(wrapper.text()).toContain('profile.memberSince')
+          })
+
+          it('date', () => {
+            expect(wrapper.text()).toContain('2020-01-23T06:38:58.813Z')
+          })
+        })
+
+        it('displays about of the user', () => {
+          expect(wrapper.text()).toContain('Oh! I am so excited about me and myself …')
+        })
+
+        describe('user ID', () => {
+          it('displays description identifier', () => {
+            expect(wrapper.text()).toContain('profile.userId')
+          })
+
+          it('displays ID', () => {
+            expect(wrapper.text()).toContain('f26bc193-605d-4465-994e-c2f328d9db01')
+          })
         })
       })
     })

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -85,6 +85,10 @@
             </ds-space>
           </template>
         </ds-card>
+        <!-- User ID -->
+        <ds-text color="softer" size="small" class="hyphenate-text" style="text-align: center;">
+          <small>{{ $t('profile.userId') }}: {{ user.id }}</small>
+        </ds-text>
         <ds-space />
         <ds-heading tag="h3" soft style="text-align: center; margin-bottom: 10px;">
           {{ $t('profile.network.title') }}


### PR DESCRIPTION
> [<img alt="Tirokk" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Tirokk) **Authored by [Tirokk](https://github.com/Tirokk)**
_<time datetime="2020-01-23T08:23:25Z" title="Thursday, January 23rd 2020, 9:23:25 am +01:00">Jan 23, 2020</time>_
_Closed <time datetime="2020-04-01T06:12:01Z" title="Wednesday, April 1st 2020, 8:12:01 am +02:00">Apr 1, 2020</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Show user ID on the user profile somewhere underneath small and grey.

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->
- fixes #252

### Todo
<!-- In case some parts are still missing, list them here. -->
- [x] implement testing
- [x] implement several other tests for the user profile page as well
- [ ] change the title of the page to contain the user name and slug

### Look actually like

<img width="1876" alt="Bildschirmfoto 2020-01-23 um 09 41 47" src="https://user-images.githubusercontent.com/25344101/72968890-b3f0ab80-3dc4-11ea-842a-824ae3fbd200.png">
