### PR TITLE
fix: Use original createdAt for merged users/emails

### DIFF
--- a/backend/src/db/migrations/20200123150105-merge_duplicate_user_accounts.js
+++ b/backend/src/db/migrations/20200123150105-merge_duplicate_user_accounts.js
@@ -34,12 +34,11 @@ export function up(next) {
                 return txc
                   .run(
                     `
-                  MATCH (oldUser:User)-[:PRIMARY_EMAIL]->(oldEmail:EmailAddress {email: $email}), (oldUser)-[previousRelationship]-(oldEmail)
+                  MATCH (oldUser:User)-[:PRIMARY_EMAIL]->(oldEmail:EmailAddress {email: $email})
                   MATCH (user:User)-[:PRIMARY_EMAIL]->(email:EmailAddress {email: $normalizedEmail})
-                  DELETE previousRelationship
                   WITH oldUser, oldEmail, user, email
-                  CALL apoc.refactor.mergeNodes([user, oldUser], { properties: 'discard', mergeRels: true }) YIELD node as mergedUser
-                  CALL apoc.refactor.mergeNodes([email, oldEmail], { properties: 'discard', mergeRels: true }) YIELD node as mergedEmail
+                  CALL apoc.refactor.mergeNodes([user, oldUser], { properties: { createdAt: 'overwrite', \`.*\`: 'discard' }, mergeRels: true }) YIELD node as mergedUser
+                  CALL apoc.refactor.mergeNodes([email, oldEmail], { properties: { createdAt: 'overwrite', verifiedAt: 'overwrite', \`.*\`: 'discard' }, mergeRels: true }) YIELD node as mergedEmail
                   RETURN user {.*}, email {.*}
               `,
                     { email, normalizedEmail },


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-02-03T17:03:42Z" title="Monday, February 3rd 2020, 6:03:42 pm +01:00">Feb 3, 2020</time>_
_Merged <time datetime="2020-02-03T18:17:48Z" title="Monday, February 3rd 2020, 7:17:48 pm +01:00">Feb 3, 2020</time>_
---

- Also, use original verifiedAt date for emails. These users only have
  newly created accounts/emails because of our blunder. Their nodes
should reflect when they became members/verified their emails.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #2967 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
