### PR TITLE
fix: Search for Hyphens

### DIFF
--- a/backend/src/schema/resolvers/searches.js
+++ b/backend/src/schema/resolvers/searches.js
@@ -8,7 +8,8 @@ export default {
       // see http://lucene.apache.org/core/8_3_1/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description
       const myQuery = query
         .replace(/\s+/g, ' ')
-        .replace(/[[@#:*~\\$|^\]?/"'(){}+?!,.-;]/g, '')
+        .replace(/[[@#:*~\\$|^\]?/"'(){}+?!,.;]/g, '')
+        .replace(/-/g, ' ')
         .split(' ')
         .map(s => (s.toLowerCase().match(/^(not|and|or)$/) ? '"' + s + '"' : s + '*'))
         .join(' ')


### PR DESCRIPTION
> [<img alt="Mogge" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Mogge) **Authored by [Mogge](https://github.com/Mogge)**
_<time datetime="2020-02-06T20:39:49Z" title="Thursday, February 6th 2020, 9:39:49 pm +01:00">Feb 6, 2020</time>_
_Closed <time datetime="2020-03-10T00:13:39Z" title="Tuesday, March 10th 2020, 1:13:39 am +01:00">Mar 10, 2020</time>_
---

## 🍰 Pullrequest
In the search query, the hyphen is replaced by a space.

### Issues
- fixes #2798 
