### PR TITLE
fix: Search For Words With Less Than Three Chars

### DIFF
--- a/webapp/components/generic/SearchableInput/SearchableInput.vue
+++ b/webapp/components/generic/SearchableInput/SearchableInput.vue
@@ -89,9 +89,18 @@ export default {
     },
     handleInput(event) {
       clearTimeout(this.searchProcess)
-      this.value = event.target ? event.target.value.replace(/\s+/g, ' ').trim() : ''
+      this.value = event.target ? event.target.value.replace(/[-\s]+/g, ' ').trim() : ''
       this.unprocessedSearchInput = this.value
-      if (isEmpty(this.value) || this.value.replace(/\s+/g, '').length < 3) {
+      if (isEmpty(this.value)) {
+        return
+      }
+      if (this.value.includes(' ')) {
+        this.value = this.value
+          .split(' ')
+          .filter(word => word.length > 2)
+          .join(' ')
+      }
+      if (this.value.length < 3) {
         return
       }
       this.searchProcess = setTimeout(() => {


### PR DESCRIPTION
> [<img alt="Mogge" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Mogge) **Authored by [Mogge](https://github.com/Mogge)**
_<time datetime="2020-02-06T21:45:33Z" title="Thursday, February 6th 2020, 10:45:33 pm +01:00">Feb 6, 2020</time>_
_Closed <time datetime="2020-03-10T11:20:02Z" title="Tuesday, March 10th 2020, 12:20:02 pm +01:00">Mar 10, 2020</time>_
---

## 🍰 Pullrequest

Hyphens are replaced by one space, which also fixes the hyphen search, this time in the frontend.
If the search string contains spaces, only words with at least three chars are passed to the backend.

### Issues
- fixes #2799 
