### PR TITLE
fix(frontend): avatar image covers full circle

### DIFF
--- a/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
+++ b/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
@@ -76,6 +76,7 @@ export default {
   > .image {
     position: relative;
     width: 100%;
+    height: 100%;
     object-fit: cover;
     object-position: center;
   }


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2020-02-18T15:21:40Z" title="Tuesday, February 18th 2020, 4:21:40 pm +01:00">Feb 18, 2020</time>_
_Merged <time datetime="2020-02-18T16:34:42Z" title="Tuesday, February 18th 2020, 5:34:42 pm +01:00">Feb 18, 2020</time>_
---

## 🍰 Pullrequest
make sure avatar image spans 100% width and height, so that the background is hidden

before:
<img width="47" alt="Screenshot 2020-02-18 at 16 22 23" src="https://user-images.githubusercontent.com/11694483/74749748-eaf29980-526a-11ea-9b94-b5abdaaf9391.png">

after:
<img width="45" alt="Screenshot 2020-02-18 at 16 22 31" src="https://user-images.githubusercontent.com/11694483/74749759-efb74d80-526a-11ea-9bf9-74795657fac9.png">

### Issues
- fixes #3025 
