### PR TITLE
fix: Update user.updatedAt when password is reset

### DIFF
--- a/backend/src/schema/resolvers/passwordReset.js
+++ b/backend/src/schema/resolvers/passwordReset.js
@@ -22,6 +22,7 @@ export default {
               WHERE duration.between(passwordReset.issuedAt, datetime()).days <= 0 AND passwordReset.usedAt IS NULL
               SET passwordReset.usedAt = datetime()
               SET user.encryptedPassword = $encryptedNewPassword
+              SET user.updatedAt = toString(datetime())
               RETURN passwordReset
             `,
             {


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-03-02T14:35:56Z" title="Monday, March 2nd 2020, 3:35:56 pm +01:00">Mar 2, 2020</time>_
_Merged <time datetime="2020-03-02T15:18:25Z" title="Monday, March 2nd 2020, 4:18:25 pm +01:00">Mar 2, 2020</time>_
---

- this is updating the user node, so it should update the updatedAt.
we recently ran into an issue where we weren't sure if a user had
successfully changed their password with the passwordReset, and needed
to look into it further to see if the PasswordReset had been used or not
to tell if it was successful.

