### PR TITLE
fix: layout shift [2607]

### DIFF
--- a/webapp/components/Dropdown.vue
+++ b/webapp/components/Dropdown.vue
@@ -48,11 +48,16 @@ export default {
           if (isOpen) {
             this.$nextTick(() => {
               setTimeout(() => {
-                document.getElementsByTagName('body')[0].classList.add('dropdown-open')
+                const paddingRightStyle = `${window.innerWidth - document.documentElement.clientWidth}px`
+                document.body.style.paddingRight = paddingRightStyle
+                document.querySelector('.main-navigation').style.paddingRight = paddingRightStyle
+                document.body.classList.add('dropdown-open')
               }, 20)
             })
           } else {
-            document.getElementsByTagName('body')[0].classList.remove('dropdown-open')
+            document.body.style.paddingRight = null
+            document.querySelector('.main-navigation').style.paddingRight = null
+            document.body.classList.remove('dropdown-open')
           }
         } catch (err) {}
       },

--- a/webapp/components/Dropdown.vue
+++ b/webapp/components/Dropdown.vue
@@ -48,16 +48,23 @@ export default {
           if (isOpen) {
             this.$nextTick(() => {
               setTimeout(() => {
-                const paddingRightStyle = `${window.innerWidth - document.documentElement.clientWidth}px`
+                const paddingRightStyle = `${window.innerWidth -
+                  document.documentElement.clientWidth}px`
+                const navigationElement = document.querySelector('.main-navigation')
                 document.body.style.paddingRight = paddingRightStyle
-                document.querySelector('.main-navigation').style.paddingRight = paddingRightStyle
                 document.body.classList.add('dropdown-open')
+                if (navigationElement) {
+                  navigationElement.style.paddingRight = paddingRightStyle
+                }
               }, 20)
             })
           } else {
+            const navigationElement = document.querySelector('.main-navigation')
             document.body.style.paddingRight = null
-            document.querySelector('.main-navigation').style.paddingRight = null
             document.body.classList.remove('dropdown-open')
+            if (navigationElement) {
+              navigationElement.style.paddingRight = null
+            }
           }
         } catch (err) {}
       },


### PR DESCRIPTION
> [<img alt="rbeer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/rbeer) **Authored by [rbeer](https://github.com/rbeer)**
_<time datetime="2020-03-05T11:07:07Z" title="Thursday, March 5th 2020, 12:07:07 pm +01:00">Mar 5, 2020</time>_
_Merged <time datetime="2020-03-10T12:01:23Z" title="Tuesday, March 10th 2020, 1:01:23 pm +01:00">Mar 10, 2020</time>_
---

## 🍰 Pullrequest
This change

1. calculates the width of the vertical scrollbar (_px-value_)
2. sets _px-value_ as `padding-right` to `.main-navigation` and `body`

thus preventing the page's content from shifting when filling up space that the disappearing scrollbar leaves behind.

![hc_dropdowns-2020-02-24_17 31 41](https://user-images.githubusercontent.com/3411649/75172519-ae70e300-572d-11ea-8f3f-294d976fe664.gif)


### Issues
- fixes #2607 
- relates #2564 

Remake of #3151