### PR TITLE
feat: more prominent output of ./scripts/translations/sort.sh

### DIFF
--- a/scripts/translations/sort.sh
+++ b/scripts/translations/sort.sh
@@ -3,6 +3,12 @@
 ROOT_DIR=$(dirname "$0")/../..
 tmp=$(mktemp)
 exit_code=0
+errors=0
+
+TEXT_RED="\e[31m"
+TEXT_BLUE="\e[34m"
+TEXT_RESET="\e[0m"
+TEXT_BOLD="\e[1m"
 
 for locale_file in $ROOT_DIR/webapp/locales/*.json
 do
@@ -16,9 +22,13 @@ do
       : # all good
     else
       exit_code=$?
-      echo "$(basename -- $locale_file) is not sorted by keys"
+      echo -e "${TEXT_BOLD}${TEXT_RED}>>> $(basename -- $locale_file) is not sorted by keys <<<${TEXT_RESET}"
+      errors=1
     fi
   fi
 done
+
+[ "$errors" = 1 ] && echo -e "${TEXT_BOLD}${TEXT_BLUE}Please run $0 --fix to sort your locale definitions!${TEXT_RESET}";
+
 
 exit $exit_code


### PR DESCRIPTION
> [<img alt="rbeer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/rbeer) **Authored by [rbeer](https://github.com/rbeer)**
_<time datetime="2020-03-10T16:51:53Z" title="Tuesday, March 10th 2020, 5:51:53 pm +01:00">Mar 10, 2020</time>_
_Merged <time datetime="2020-03-11T17:03:48Z" title="Wednesday, March 11th 2020, 6:03:48 pm +01:00">Mar 11, 2020</time>_
---

## 🍰 Pullrequest
The output of ./scripts/translations/sort.sh tends to get overlooked in the TravisCI logs.
This change makes the "x.json is not sorted by keys" prominent red and adds a hint to the sort.sh --fix feature.

Tests obviously fail now to show the error output. I will rebase out the 'temp:' commits, if approved.

Before:
![3251-travis-log-before](https://user-images.githubusercontent.com/3411649/76339714-c1bdaa00-62fa-11ea-89eb-1db456f2bed4.png)

After:
![3251-travis-log-after](https://user-images.githubusercontent.com/3411649/76339735-c84c2180-62fa-11ea-8801-5e662ce3ff18.png)

Messages in bold, --fix hint in blue - which I like better as the hint is info, not a warning and it really makes it stand out:
![3251-travis-log-bold_n_blue](https://user-images.githubusercontent.com/3411649/76344077-401d4a80-6301-11ea-892a-e7dc782a1429.png)
