### PR TITLE
fix(database): set Report.disable

### DIFF
--- a/backend/src/db/migrations/20200404100445-set_reportdisable_to_latest_review_decision.js
+++ b/backend/src/db/migrations/20200404100445-set_reportdisable_to_latest_review_decision.js
@@ -1,0 +1,58 @@
+import { getDriver } from '../../db/neo4j'
+
+export const description = ''
+
+export async function up(next) {
+  const driver = getDriver()
+  const session = driver.session()
+  const transaction = session.beginTransaction()
+
+  try {
+    const { records } = await transaction.run(`
+      MATCH (report:Report)
+      WHERE NOT exists(report.disable)
+      AND report.closed = TRUE
+      RETURN report.id as reportId;
+    `)
+    const reportIds = await records.map((record) => record.get('reportId'))
+    const updatedReports = await Promise.all(
+      reportIds
+        .map((reportId) => {
+          return async () => {
+            const updatedReportsTransactionPromise = await transaction.run(
+              `MATCH (report:Report {id: $reportId})<-[reviews:REVIEWED]-(:User)
+             WITH report, reviews, reviews.updatedAt as sortedReviews
+             ORDER BY sortedReviews DESC LIMIT 1
+             SET report.disable = reviews.disable
+             RETURN report {.*}, reviews {.*}
+            `,
+              { reportId },
+            )
+            const [updatedReport] = updatedReportsTransactionPromise.records.map((record) => ({
+              report: record.get('report'),
+              review: record.get('reviews'),
+            }))
+            return updatedReport
+          }
+        })
+        .map((p) => p()),
+    )
+    // eslint-disable-next-line no-console
+    console.log('updatedReports', updatedReports)
+    await transaction.commit()
+    next()
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    await transaction.rollback()
+    // eslint-disable-next-line no-console
+    console.log('rolled back')
+    throw new Error(error)
+  } finally {
+    session.close()
+  }
+}
+
+export async function down(next) {
+  throw new Error('Irreversible migration')
+}


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-04-04T11:04:57Z" title="Saturday, April 4th 2020, 1:04:57 pm +02:00">Apr 4, 2020</time>_

---

- we should be able to look at a resource's latest report and tell
  whether the reviews decided it should be disabled

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #3412 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] How can we test that this has used the latest review other than our knowledge of cypher queries?
