### PR TITLE
feat: 🍰 Increase Margin Of Header And Ruler For Better Legibility

### DIFF
--- a/webapp/components/Editor/ContentViewer.vue
+++ b/webapp/components/Editor/ContentViewer.vue
@@ -40,9 +40,9 @@ export default {
 }
 </script>
 <style lang="scss">
-h3,
-h4,
-hr {
-  margin: 8px 0;
+.ProseMirror h3,
+.ProseMirror h4,
+.ProseMirror hr {
+  margin: 24px 0 8px;
 }
 </style>

--- a/webapp/components/Editor/ContentViewer.vue
+++ b/webapp/components/Editor/ContentViewer.vue
@@ -39,3 +39,10 @@ export default {
   },
 }
 </script>
+<style lang="scss">
+h3,
+h4,
+hr {
+  margin: 8px 0;
+}
+</style>


### PR DESCRIPTION
> [<img alt="ritesh-pandey" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/ritesh-pandey) **Authored by [ritesh-pandey](https://github.com/ritesh-pandey)**
_<time datetime="2020-08-04T13:12:12Z" title="Tuesday, August 4th 2020, 3:12:12 pm +02:00">Aug 4, 2020</time>_
_Merged <time datetime="2020-08-05T09:28:05Z" title="Wednesday, August 5th 2020, 11:28:05 am +02:00">Aug 5, 2020</time>_
---

Margin of H3 H4 HR was set to zero by reset.css. This was causing
problem in readability.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
Add `margin` CSS rule to `Editor/ContentEditor.vue` component.

Before
![Screenshot from 2020-08-04 18-35-13](https://user-images.githubusercontent.com/1433681/89297665-de7bc500-d681-11ea-9113-4019d0232a59.png)

After
![Screenshot from 2020-08-04 18-35-37](https://user-images.githubusercontent.com/1433681/89297605-c5731400-d681-11ea-93ba-769c8fbdda61.png)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #3628 
- relates #XXX
-->
- fixes #3628 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
